### PR TITLE
2. Makefile rewrite & ASSERT update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ your distribution has an older version, you can install a new one by:
 
 Then build everything by running:
 
-    make release && make
+    make
 
-Output binary will be created in `build/src/demos-sched` for native build.
+Output binary will be created in `build/src/demos-sched` for the native build.
+
+To compile a debug build of DEmOS, run `make debug` (this configures
+the build type), followed by `make`.
 
 ### Cross compilation
 

--- a/meson_aarch64.txt
+++ b/meson_aarch64.txt
@@ -11,7 +11,7 @@ cpp = 'aarch64-linux-gnu-g++'
 ar = 'aarch64-linux-gnu-ar'
 strip = 'aarch64-linux-gnu-strip'
 
-[properties]
+[built-in options]
 cpp_link_args = ['-static']
 
 [host_machine]

--- a/src/cpufreq_policy.hpp
+++ b/src/cpufreq_policy.hpp
@@ -102,9 +102,8 @@ public: ////////////////////////////////////////////////////////////////////////
     {
         if (!active) return;
 
-        // TODO: toggle this using a macro
         // check that freq is between min-max and is one of the supported frequencies
-        validate_frequency(freq);
+        RUN_DEBUG(validate_frequency(freq));
 
         TRACE("Changing CPU frequency to `{}` for `{}`", freq_to_str(freq), name);
         // cpufreq uses kHz, we have Hz

--- a/src/lib/assert.hpp
+++ b/src/lib/assert.hpp
@@ -25,11 +25,13 @@ public:
     }
 };
 
-#ifdef NDEBUG
-#define ASSERT(expr) (static_cast<void>(0))
-#else
+#ifdef DEBUG
 #define ASSERT(expr)                                                                               \
     (static_cast<bool>(expr)                                                                       \
        ? void(0)                                                                                   \
        : throw assertion_error(#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__))
+#define RUN_DEBUG(expr) void(expr)
+#else
+#define ASSERT(expr) (static_cast<void>(0))
+#define RUN_DEBUG(expr) void(0)
 #endif

--- a/src/lib/assert.hpp
+++ b/src/lib/assert.hpp
@@ -32,6 +32,9 @@ public:
        : throw assertion_error(#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__))
 #define RUN_DEBUG(expr) void(expr)
 #else
-#define ASSERT(expr) (static_cast<void>(0))
-#define RUN_DEBUG(expr) void(0)
+// type-check the assert expressions even in release mode, but don't run them
+//  (compiler should optimize this away into a no-op)
+// the inner (void)(expr) suppresses the "expression result unused" warning
+#define RUN_DEBUG(expr) void(true || ((void)(expr), false))
+#define ASSERT(expr) RUN_DEBUG(expr)
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "cgroup_setup.hpp"
 #include "config.hpp"
 #include "demos_scheduler.hpp"
+#include "lib/assert.hpp"
 #include "lib/check_lib.hpp"
 #include <sched.h>
 
@@ -137,6 +138,7 @@ int main(int argc, char *argv[])
         // === CONFIG LOADING ======================================================================
         // this print is useful to roughly measure startup times
         logger->debug("Starting DEmOS");
+        RUN_DEBUG(TRACE("Compiled in debug mode"));
         logger->trace("Loading configuration");
         Config config;
         if (!config_file.empty()) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,7 +7,9 @@ executable('demos-sched',
 	 'cgroup.cpp', 'cgroup_setup.cpp', 'timerfd.cpp', 'evfd.cpp',
 	 'config.cpp', 'lib/cpuset.c', 'log.cpp'],
 	cpp_args : cxx.get_supported_arguments(['-Wsuggest-attribute=const']) +
-		[ '-DHAVE_DECL_CPU_ALLOC' ], # See cpuset.h
+		[ '-DHAVE_DECL_CPU_ALLOC' ] + # see cpuset.h
+		(get_option('buildtype').startswith('debug') ? [ '-DDEBUG' ] : []),
+		# /\ if compiling a debug build, set a global DEBUG preprocessor flag
 	dependencies : [libev_dep, yaml_cpp_dep, spdlog_dep],
 	install : true)
 


### PR DESCRIPTION
Updated Makefile, which simplifies the first-time compilation, is more maintainable, and correctly sets up release build.