### PR TITLE
Use std::map as power policy registry

### DIFF
--- a/src/power_policy/_power_policy.cpp
+++ b/src/power_policy/_power_policy.cpp
@@ -1,6 +1,8 @@
 #include "power_policy/_power_policy.hpp"
 #include "log.hpp"
 #include <algorithm>
+#include <map>
+#include <string>
 
 // TODO: MK: possibly create a meson build step that lists power policies
 //  inside this directory, and generates both includes and PP(...) calls
@@ -20,17 +22,31 @@
 #define ARR_ARGS_2(arr_name) ARR_ARGS_1(arr_name), arr_name[1]
 #define ARR_ARGS_3(arr_name) ARR_ARGS_2(arr_name), arr_name[2]
 #define ARR_ARGS_4(arr_name) ARR_ARGS_3(arr_name), arr_name[3]
-#define PP(name, class_, arg_count)                                                                \
-    do {                                                                                           \
-        if (policy_name == name) {                                                                 \
-            if (arg_count != policy_args.size()) { /* NOLINT(readability-container-size-empty) */  \
-                throw runtime_error(                                                               \
-                  "Incorrect number of parameters for the '" name "' power policy; got " +         \
-                  std::to_string(policy_args.size()) + ", expected " #arg_count);                  \
-            }                                                                                      \
-            return std::make_unique<class_>(ARR_ARGS_##arg_count(policy_args));                    \
-        }                                                                                          \
-    } while (0)
+#define PP(name, class_, arg_count)                                                                     \
+    { /* this is std::pair */                                                                           \
+        name, [](const std::vector<std::string> &policy_args) {                                         \
+            if (arg_count != policy_args.size()) { /* NOLINT(readability-container-size-empty) */       \
+                throw runtime_error(                                                                    \
+                    "Incorrect number of parameters for the '" name "' power policy; got " +            \
+                    std::to_string(policy_args.size()) + ", expected " #arg_count);                     \
+            }                                                                                           \
+            return std::make_unique<class_>(ARR_ARGS_##arg_count(policy_args));                         \
+        }                                                                                               \
+    }
+
+static const std::map<std::string,
+                      std::function<std::unique_ptr<PowerPolicy>(const std::vector<std::string> &)>>
+  power_policies{
+      // the function in each of these macros validates the number of
+      //  arguments and creates a unique_ptr<PowerPolicy_...>, passing the arguments
+      //  provided by the user
+      PP("minbe", PowerPolicy_MinBE, 0),
+      PP("low", PowerPolicy_FixedLow, 0),
+      PP("high", PowerPolicy_FixedHigh, 0),
+      PP("imx8_alternating", PowerPolicy_Imx8_Alternating, 4),
+      PP("imx8_fixed", PowerPolicy_Imx8_Fixed, 2),
+  };
+
 
 static std::unique_ptr<PowerPolicy> instantiate_power_policy(
   const std::string &policy_name,
@@ -50,16 +66,14 @@ static std::unique_ptr<PowerPolicy> instantiate_power_policy(
                  policy_name,
                  fmt::join(policy_args, ","));
 
-    // each of these macros checks if the policy name matches, validates the number of
-    //  arguments and creates a unique_ptr<PowerPolicy_...>, passing the arguments
-    //  provided by the user
-    PP("minbe", PowerPolicy_MinBE, 0);
-    PP("low", PowerPolicy_FixedLow, 0);
-    PP("high", PowerPolicy_FixedHigh, 0);
-    PP("imx8_alternating", PowerPolicy_Imx8_Alternating, 4);
-    PP("imx8_fixed", PowerPolicy_Imx8_Fixed, 2);
-
-    throw std::runtime_error("Unknown power policy selected: " + policy_name);
+    try {
+        return power_policies.at(policy_name)(policy_args);
+    } catch (const std::out_of_range &) {
+        std::string all_pp;
+        for (auto const& [pp, val] : power_policies)
+            all_pp += (all_pp.empty() ? "" : ", ") + pp;
+        throw std::runtime_error("Unknown power policy selected: " + policy_name + "; available policies: " + all_pp);
+    }
 }
 
 std::unique_ptr<PowerPolicy> PowerPolicy::setup_power_policy(const std::string &policy_str)


### PR DESCRIPTION
This allows to print the list of available policies to the user in an
error message.