### PR TITLE
2) Per-process power policy

### DIFF
--- a/src/cgroup.hpp
+++ b/src/cgroup.hpp
@@ -68,6 +68,7 @@ public:
     ~CgroupCpuset();
 
     void set_cpus(cpu_set cpus);
+    const cpu_set& get_cpus() const { return current_cpus; }
 
 private:
     int fd_cpus;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -67,7 +67,7 @@ static Node normalize_process(const Node &proc, float default_budget)
                 // if true, we wait until the process completes initialization
                 //  before freezing it and starting normal scheduling
                 norm_proc[k] = proc[k].as<bool>();
-            } else if (k == "_a53_freq" || k == "_a72_freq") {
+            } else if (k == "frequency") {
                 // TODO: when the interface is finalized, remove the leading underscore
                 norm_proc[k] = proc[k].as<unsigned int>();
             } else {
@@ -432,22 +432,16 @@ void Config::create_scheduler_objects(const CgroupConfig &c,
         for (const auto &yprocess : ypart["processes"]) {
             auto budget = chrono::milliseconds(yprocess["budget"].as<int>());
             auto budget_jitter = chrono::milliseconds(yprocess["jitter"].as<int>());
-            // the freqs are already checked during validation, they should be correct
-            auto _a53_freq = yprocess["_a53_freq"]
+            auto req_freq = yprocess["frequency"]
                                ? std::optional(CpuFrequencyHz{
-                                   1000 * 1000 * yprocess["_a53_freq"].as<unsigned int>() })
-                               : std::nullopt;
-            auto _a72_freq = yprocess["_a72_freq"]
-                               ? std::optional(CpuFrequencyHz{
-                                   1000 * 1000 * yprocess["_a72_freq"].as<unsigned int>() })
+                                   1000 * 1000 * yprocess["frequency"].as<unsigned int>() })
                                : std::nullopt;
             partitions.back().add_process(c.loop,
                                           yprocess["cmd"].as<string>(),
                                           process_cwd,
                                           budget,
                                           budget_jitter,
-                                          _a53_freq,
-                                          _a72_freq,
+                                          req_freq,
                                           yprocess["init"].as<bool>());
         }
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -560,14 +560,14 @@ void Config::create_scheduler_objects(const CgroupConfig &c,
             auto budget = chrono::milliseconds(yprocess["budget"].as<int>());
             auto budget_jitter = chrono::milliseconds(yprocess["jitter"].as<int>());
             // the freqs are already checked during validation, they should be correct
-            auto _a53_freq =
-              yprocess["_a53_freq"]
-                ? std::optional(1000 * 1000 * yprocess["_a53_freq"].as<unsigned int>())
-                : std::nullopt;
-            auto _a72_freq =
-              yprocess["_a72_freq"]
-                ? std::optional(1000 * 1000 * yprocess["_a72_freq"].as<unsigned int>())
-                : std::nullopt;
+            auto _a53_freq = yprocess["_a53_freq"]
+                               ? std::optional(CpuFrequencyHz{
+                                   1000 * 1000 * yprocess["_a53_freq"].as<unsigned int>() })
+                               : std::nullopt;
+            auto _a72_freq = yprocess["_a72_freq"]
+                               ? std::optional(CpuFrequencyHz{
+                                   1000 * 1000 * yprocess["_a72_freq"].as<unsigned int>() })
+                               : std::nullopt;
             partitions.back().add_process(c.loop,
                                           yprocess["cmd"].as<string>(),
                                           process_cwd,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -498,4 +498,6 @@ void Config::create_scheduler_objects(const CgroupConfig &c,
             w.add_slice(sc_part_ptr, be_part_ptr, cpus);
         }
     }
+
+    c.power_policy.validate(windows);
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,5 +1,6 @@
 #include "config.hpp"
 #include "log.hpp"
+#include "power_policy/_power_policy.hpp"
 #include <cmath>
 #include <exception>
 #include <lib/assert.hpp>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -416,6 +416,7 @@ void Config::create_scheduler_objects(const CgroupConfig &c,
                                       Windows &windows,
                                       Partitions &partitions)
 {
+    bool ppf_warned = false;
     optional<filesystem::path> process_cwd{};
     if (config["set_cwd"].as<bool>()) {
         ASSERT(config_file_path != nullopt);
@@ -437,6 +438,10 @@ void Config::create_scheduler_objects(const CgroupConfig &c,
                                ? std::optional(CpuFrequencyHz{
                                    1000 * 1000 * yprocess["frequency"].as<unsigned int>() })
                                : std::nullopt;
+            if (req_freq && !c.power_policy.supports_per_process_frequencies() && !ppf_warned) {
+                logger->warn("Per-processes frequency specified in the configuration, but not supported by the power policy.");
+                ppf_warned = true;
+            }
             partitions.back().add_process(c.loop,
                                           yprocess["cmd"].as<string>(),
                                           process_cwd,

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -35,6 +35,9 @@ private:
     std::optional<std::filesystem::path> config_file_path{};
     int anonymous_partition_counter = 0;
 
+    void validate_config();
+    void validate_per_process_freq_feasibility();
+
     YAML::Node normalize_window(const YAML::Node &win, YAML::Node &partitions);
     YAML::Node normalize_partition(const YAML::Node &part, float total_budget);
     YAML::Node normalize_slice(const YAML::Node &slice, float win_length, YAML::Node &partitions);

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -36,7 +36,6 @@ private:
     int anonymous_partition_counter = 0;
 
     void validate_config();
-    void validate_per_process_freq_feasibility();
 
     YAML::Node normalize_window(const YAML::Node &win, YAML::Node &partitions);
     YAML::Node normalize_partition(const YAML::Node &part, float total_budget);

--- a/src/cpufreq_policy.hpp
+++ b/src/cpufreq_policy.hpp
@@ -192,12 +192,13 @@ public: ////////////////////////////////////////////////////////////////////////
               available_frequencies->end()) {
             throw runtime_error("Attempted to set CPU frequency for `" + name + "` to `" +
                                 std::to_string(freq) +
-                                "` Hz, which is not listed as an available frequency for this CPU");
+                                "` Hz, but this CPU supports only the following frequencies: " +
+                                get_available_freq_str());
         }
     }
 
 private: ///////////////////////////////////////////////////////////////////////////////////////////
-    string get_available_freq_str()
+    string get_available_freq_str() const
     {
         if (!available_frequencies) {
             return "unknown";

--- a/src/cpufreq_policy.hpp
+++ b/src/cpufreq_policy.hpp
@@ -173,7 +173,7 @@ public: ////////////////////////////////////////////////////////////////////////
         write_frequency(get_freq(index));
     }
 
-    void validate_frequency(CpuFrequencyHz freq)
+    void validate_frequency(CpuFrequencyHz freq) const
     {
         if (freq < min_frequency) {
             throw runtime_error("Attempted to set CPU frequency for `" + name + "` to `" +

--- a/src/cpufreq_policy.hpp
+++ b/src/cpufreq_policy.hpp
@@ -173,15 +173,6 @@ public: ////////////////////////////////////////////////////////////////////////
         write_frequency(get_freq(index));
     }
 
-private: ///////////////////////////////////////////////////////////////////////////////////////////
-    string get_available_freq_str()
-    {
-        if (!available_frequencies) {
-            return "unknown";
-        }
-        return fmt::format("{}", fmt::join(available_frequencies.value(), ", "));
-    }
-
     void validate_frequency(CpuFrequencyHz freq)
     {
         if (freq < min_frequency) {
@@ -203,6 +194,15 @@ private: ///////////////////////////////////////////////////////////////////////
                                 std::to_string(freq) +
                                 "` Hz, which is not listed as an available frequency for this CPU");
         }
+    }
+
+private: ///////////////////////////////////////////////////////////////////////////////////////////
+    string get_available_freq_str()
+    {
+        if (!available_frequencies) {
+            return "unknown";
+        }
+        return fmt::format("{}", fmt::join(available_frequencies.value(), ", "));
     }
 
     string read_governor()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "demos_scheduler.hpp"
 #include "lib/assert.hpp"
 #include "lib/check_lib.hpp"
+#include "power_policy/_power_policy.hpp"
 #include <sched.h>
 
 using namespace std;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,8 +208,8 @@ int main(int argc, char *argv[])
         // this spawns the underlying system processes
         sched.setup();
 
-        // configure linux scheduler - set highest possible priority for demos
-        // should be called after child process creation (in `sched.setup()`),
+        // configure linux scheduler - set the highest possible priority for demos
+        // must be called after child process creation (in `sched.setup()`),
         //  as we don't want children to inherit RT priority
         struct sched_param sp = { .sched_priority = 99 };
         if (sched_setscheduler(0, SCHED_FIFO, &sp) == -1) {
@@ -228,6 +228,9 @@ int main(int argc, char *argv[])
         // everything is set up now, start the event loop
         // the event loop terminates either on timeout (if set),
         //  SIGTERM, SIGINT (Ctrl-c), or when all scheduled processes exit
+        // FIXME: when a runtime error occurs, cgroups are not cleaned up, because
+        //  they're not empty; catch the exception here, attempt to cleanup (sched.initiate_shutdown),
+        //  then rethrow (if it fails, throw immediately)
         scheduler_timeout ? sched.run(scheduler_timeout.value()) : sched.run();
 
     } catch (const exception &e) {

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -27,6 +27,8 @@ void Partition::add_process(ev::loop_ref loop,
                             const optional<filesystem::path> &working_dir,
                             chrono::milliseconds budget,
                             chrono::milliseconds budget_jitter,
+                            std::optional<unsigned int> a53_freq,
+                            std::optional<unsigned int> a72_freq,
                             bool has_initialization)
 {
     processes.emplace_back(loop,
@@ -36,6 +38,8 @@ void Partition::add_process(ev::loop_ref loop,
                            working_dir,
                            budget,
                            budget_jitter,
+                           a53_freq,
+                           a72_freq,
                            has_initialization);
     proc_count++;
     current_proc = processes.begin();

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -27,8 +27,8 @@ void Partition::add_process(ev::loop_ref loop,
                             const optional<filesystem::path> &working_dir,
                             chrono::milliseconds budget,
                             chrono::milliseconds budget_jitter,
-                            std::optional<unsigned int> a53_freq,
-                            std::optional<unsigned int> a72_freq,
+                            std::optional<CpuFrequencyHz> a53_freq,
+                            std::optional<CpuFrequencyHz> a72_freq,
                             bool has_initialization)
 {
     processes.emplace_back(loop,

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -67,7 +67,6 @@ void Partition::reset(bool move_to_first_proc,
 
     clear_completed_flag();
     cgc.set_cpus(cpus);
-    current_cpus = cpus;
     _completed_cb = process_completion_cb;
     // for BE partition, we don't want to reset to first process
     if (move_to_first_proc) {

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -27,8 +27,7 @@ void Partition::add_process(ev::loop_ref loop,
                             const optional<filesystem::path> &working_dir,
                             chrono::milliseconds budget,
                             chrono::milliseconds budget_jitter,
-                            std::optional<CpuFrequencyHz> a53_freq,
-                            std::optional<CpuFrequencyHz> a72_freq,
+                            std::optional<CpuFrequencyHz> req_freq,
                             bool has_initialization)
 {
     processes.emplace_back(loop,
@@ -38,8 +37,7 @@ void Partition::add_process(ev::loop_ref loop,
                            working_dir,
                            budget,
                            budget_jitter,
-                           a53_freq,
-                           a72_freq,
+                           req_freq,
                            has_initialization);
     proc_count++;
     current_proc = processes.begin();

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -63,6 +63,7 @@ void Partition::reset(bool move_to_first_proc,
 
     clear_completed_flag();
     cgc.set_cpus(cpus);
+    current_cpus = cpus;
     _completed_cb = process_completion_cb;
     // for BE partition, we don't want to reset to first process
     if (move_to_first_proc) {

--- a/src/partition.hpp
+++ b/src/partition.hpp
@@ -73,8 +73,7 @@ public:
                      const std::optional<std::filesystem::path> &working_dir,
                      std::chrono::milliseconds budget,
                      std::chrono::milliseconds budget_jitter,
-                     std::optional<CpuFrequencyHz> a53_freq,
-                     std::optional<CpuFrequencyHz> a72_freq,
+                     std::optional<CpuFrequencyHz> req_freq,
                      bool has_initialization);
 
     /** Spawns system processes for all added Process instances. */

--- a/src/partition.hpp
+++ b/src/partition.hpp
@@ -73,8 +73,8 @@ public:
                      const std::optional<std::filesystem::path> &working_dir,
                      std::chrono::milliseconds budget,
                      std::chrono::milliseconds budget_jitter,
-                     std::optional<unsigned int> a53_freq,
-                     std::optional<unsigned int> a72_freq,
+                     std::optional<CpuFrequencyHz> a53_freq,
+                     std::optional<CpuFrequencyHz> a72_freq,
                      bool has_initialization);
 
     /** Spawns system processes for all added Process instances. */

--- a/src/partition.hpp
+++ b/src/partition.hpp
@@ -53,6 +53,8 @@ public:
     // Note: `processes` MUST be located after all cgroups (cgc, cgf, cge) - Process destructors
     //  must run before the cgroup destructors to cleanup child cgroups in correct order
     Processes processes{};
+    /** Current cpu_set the partition is running under. */
+    cpu_set current_cpus{};
 
 public:
     Partition(Cgroup &freezer_parent,

--- a/src/partition.hpp
+++ b/src/partition.hpp
@@ -73,6 +73,8 @@ public:
                      const std::optional<std::filesystem::path> &working_dir,
                      std::chrono::milliseconds budget,
                      std::chrono::milliseconds budget_jitter,
+                     std::optional<unsigned int> a53_freq,
+                     std::optional<unsigned int> a72_freq,
                      bool has_initialization);
 
     /** Spawns system processes for all added Process instances. */

--- a/src/partition.hpp
+++ b/src/partition.hpp
@@ -54,7 +54,7 @@ public:
     //  must run before the cgroup destructors to cleanup child cgroups in correct order
     Processes processes{};
     /** Current cpu_set the partition is running under. */
-    cpu_set current_cpus{};
+    const cpu_set& current_cpus() { return cgc.get_cpus(); }
 
 public:
     Partition(Cgroup &freezer_parent,

--- a/src/power_policy/_power_policy.cpp
+++ b/src/power_policy/_power_policy.cpp
@@ -9,6 +9,7 @@
 #include "power_policy/high.hpp"
 #include "power_policy/imx8_alternating.hpp"
 #include "power_policy/imx8_fixed.hpp"
+#include "power_policy/imx8_per_process.hpp"
 #include "power_policy/low.hpp"
 #include "power_policy/minbe.hpp"
 #include "power_policy/none.hpp"
@@ -45,6 +46,7 @@ static const std::map<std::string,
       PP("high", PowerPolicy_FixedHigh, 0),
       PP("imx8_alternating", PowerPolicy_Imx8_Alternating, 4),
       PP("imx8_fixed", PowerPolicy_Imx8_Fixed, 2),
+      PP("imx8_per_process", PowerPolicy_Imx8_PerProcess, 0),
   };
 
 

--- a/src/power_policy/_power_policy.cpp
+++ b/src/power_policy/_power_policy.cpp
@@ -10,6 +10,7 @@
 #include "power_policy/imx8_alternating.hpp"
 #include "power_policy/imx8_fixed.hpp"
 #include "power_policy/imx8_per_process.hpp"
+#include "power_policy/imx8_per_slice.hpp"
 #include "power_policy/low.hpp"
 #include "power_policy/minbe.hpp"
 #include "power_policy/none.hpp"
@@ -47,6 +48,7 @@ static const std::map<std::string,
       PP("imx8_alternating", PowerPolicy_Imx8_Alternating, 4),
       PP("imx8_fixed", PowerPolicy_Imx8_Fixed, 2),
       PP("imx8_per_process", PowerPolicy_Imx8_PerProcess, 0),
+      PP("imx8_per_slice", PowerPolicy_Imx8_PerSlice, 0),
   };
 
 

--- a/src/power_policy/_power_policy.hpp
+++ b/src/power_policy/_power_policy.hpp
@@ -23,6 +23,7 @@ public:
 
     virtual void validate(const Windows &) {}
     virtual bool supports_per_process_frequencies() { return false; }
+    virtual bool supports_per_slice_frequencies() { return false; }
 
     virtual void on_window_start(Window &) {}
     virtual void on_sc_start(Window &) {}

--- a/src/power_policy/_power_policy.hpp
+++ b/src/power_policy/_power_policy.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <memory>
+#include <power_manager.hpp>
 #include <process.hpp>
 
+// forward declaration to avoid circular dependency between PowerPolicy and Window
 class Window;
 
 /**
@@ -38,4 +40,14 @@ public:
      * `<policy_name>:<arg1>,<arg2>,...`
      */
     static std::unique_ptr<PowerPolicy> setup_power_policy(const std::string &policy_str);
+};
+
+/**
+ * Subclass of PowerPolicy, which is extended by power policy implementations
+ * which use PowerManager. In the rest of the codebase, you should accept
+ * the more general PowerPolicy interface instead of this one.
+ */
+class PmPowerPolicy : public PowerPolicy {
+protected:
+    PowerManager pm{};
 };

--- a/src/power_policy/_power_policy.hpp
+++ b/src/power_policy/_power_policy.hpp
@@ -21,6 +21,8 @@ class PowerPolicy
 public:
     virtual ~PowerPolicy() = default;
 
+    virtual void validate(const Windows &) {}
+
     virtual void on_window_start(Window &) {}
     virtual void on_sc_start(Window &) {}
     virtual void on_be_start(Window &) {}

--- a/src/power_policy/_power_policy.hpp
+++ b/src/power_policy/_power_policy.hpp
@@ -3,9 +3,7 @@
 #include <memory>
 #include <power_manager.hpp>
 #include <process.hpp>
-
-// forward declaration to avoid circular dependency between PowerPolicy and Window
-class Window;
+#include <window.hpp>
 
 /**
  * A virtual interface, which is injected to other components of the scheduler,

--- a/src/power_policy/_power_policy.hpp
+++ b/src/power_policy/_power_policy.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <process.hpp>
 
 class Window;
 
@@ -24,6 +25,9 @@ public:
     virtual void on_sc_start(Window &) {}
     virtual void on_be_start(Window &) {}
     virtual void on_window_end(Window &) {}
+
+    // TODO: check the performance impact, potentially hide it behind a compile-time flag
+    virtual void on_process_start(Process &) {}
 
     // it seems a bit weird to have what's essentially an input parsing function here,
     //  but imo it is still cleaner than including all defined policies in main.cpp

--- a/src/power_policy/_power_policy.hpp
+++ b/src/power_policy/_power_policy.hpp
@@ -30,6 +30,7 @@ public:
 
     // TODO: check the performance impact, potentially hide it behind a compile-time flag
     virtual void on_process_start(Process &) {}
+    virtual void on_process_end(Process &) {}
 
     // it seems a bit weird to have what's essentially an input parsing function here,
     //  but imo it is still cleaner than including all defined policies in main.cpp

--- a/src/power_policy/_power_policy.hpp
+++ b/src/power_policy/_power_policy.hpp
@@ -22,6 +22,7 @@ public:
     virtual ~PowerPolicy() = default;
 
     virtual void validate(const Windows &) {}
+    virtual bool supports_per_process_frequencies() { return false; }
 
     virtual void on_window_start(Window &) {}
     virtual void on_sc_start(Window &) {}

--- a/src/power_policy/high.hpp
+++ b/src/power_policy/high.hpp
@@ -3,11 +3,8 @@
 #include "_power_policy.hpp"
 #include "power_manager.hpp"
 
-class PowerPolicy_FixedHigh : public PowerPolicy
+class PowerPolicy_FixedHigh : public PmPowerPolicy
 {
-private:
-    PowerManager pm{};
-
 public:
     PowerPolicy_FixedHigh()
     {

--- a/src/power_policy/imx8_alternating.hpp
+++ b/src/power_policy/imx8_alternating.hpp
@@ -8,10 +8,9 @@
  *
  * NOTE: this is a test power policy, the error messages are not very helpful
  */
-class PowerPolicy_Imx8_Alternating : public PowerPolicy
+class PowerPolicy_Imx8_Alternating : public PmPowerPolicy
 {
 private:
-    PowerManager pm{};
     CpufreqPolicy &a53_pol = pm.get_policy("policy0");
     CpufreqPolicy &a72_pol = pm.get_policy("policy4");
     CpuFrequencyHz f1_a53 = 0;

--- a/src/power_policy/imx8_alternating.hpp
+++ b/src/power_policy/imx8_alternating.hpp
@@ -13,10 +13,10 @@ class PowerPolicy_Imx8_Alternating : public PmPowerPolicy
 private:
     CpufreqPolicy &a53_pol = pm.get_policy("policy0");
     CpufreqPolicy &a72_pol = pm.get_policy("policy4");
-    CpuFrequencyHz f1_a53 = 0;
-    CpuFrequencyHz f2_a53 = 0;
-    CpuFrequencyHz f1_a72 = 0;
-    CpuFrequencyHz f2_a72 = 0;
+    CpuFrequencyHz f1_a53;
+    CpuFrequencyHz f2_a53;
+    CpuFrequencyHz f1_a72;
+    CpuFrequencyHz f2_a72;
     bool f1_next = true;
 
 public:
@@ -24,6 +24,12 @@ public:
                                  const std::string &a53_f2_str,
                                  const std::string &a72_f1_str,
                                  const std::string &a72_f2_str)
+    try
+      : PmPowerPolicy{}
+      , f1_a53{ a53_pol.get_freq(std::stoul(a53_f1_str)) }
+      , f2_a53{ a53_pol.get_freq(std::stoul(a53_f2_str)) }
+      , f1_a72{ a72_pol.get_freq(std::stoul(a72_f1_str)) }
+      , f2_a72{ a72_pol.get_freq(std::stoul(a72_f2_str)) }
     {
         for (auto &p : pm.policy_iter()) {
             if (!p.available_frequencies) {
@@ -32,20 +38,12 @@ public:
             }
         }
 
-        try {
-            f1_a53 = a53_pol.get_freq(std::stoul(a53_f1_str));
-            f2_a53 = a53_pol.get_freq(std::stoul(a53_f2_str));
-
-            f1_a72 = a72_pol.get_freq(std::stoul(a72_f1_str));
-            f2_a72 = a72_pol.get_freq(std::stoul(a72_f2_str));
-        } catch (...) {
-            throw_with_nested(
-              runtime_error("All power policy arguments must be integers in the range <0, 3>"));
-        }
-
         // set fixed frequency if both "alternating" frequencies are the same
         if (f1_a53 == f2_a53) a53_pol.write_frequency(f1_a53);
         if (f1_a72 == f2_a72) a72_pol.write_frequency(f1_a72);
+    } catch (...) {
+        throw_with_nested(
+          runtime_error("All power policy arguments must be integers in the range <0, 3>"));
     }
 
     void on_window_start(Window &) override

--- a/src/power_policy/imx8_fixed.hpp
+++ b/src/power_policy/imx8_fixed.hpp
@@ -13,7 +13,7 @@ class PowerPolicy_Imx8_Fixed : public PmPowerPolicy
 {
 public:
     /** *_freq_i - integer, range <0,3> */
-    PowerPolicy_Imx8_Fixed(const std::string& a53_freq_i, const std::string& a72_freq_i)
+    PowerPolicy_Imx8_Fixed(const std::string &a53_freq_i, const std::string &a72_freq_i)
     {
         auto &a53_pol = pm.get_policy("policy0");
         auto &a72_pol = pm.get_policy("policy4");
@@ -25,15 +25,12 @@ public:
             }
         }
 
-        CpuFrequencyHz a53_freq, a72_freq;
         try {
-            a53_freq = a53_pol.get_freq(std::stoul(a53_freq_i));
-            a72_freq = a72_pol.get_freq(std::stoul(a72_freq_i));
-        } catch (...) {
-            throw runtime_error("Both power policy arguments must be integers in the range <0, 3>");
+            a53_pol.write_frequency_i(std::stoul(a53_freq_i));
+            a72_pol.write_frequency_i(std::stoul(a72_freq_i));
+        } catch (std::invalid_argument &) {
+            std::throw_with_nested(std::runtime_error(
+              "Both power policy arguments must be integers in the range <0, 3>"));
         }
-
-        a53_pol.write_frequency(a53_freq);
-        a72_pol.write_frequency(a72_freq);
     }
 };

--- a/src/power_policy/imx8_fixed.hpp
+++ b/src/power_policy/imx8_fixed.hpp
@@ -9,11 +9,8 @@
  *
  * NOTE: this is a test power policy, the error messages are not very helpful
  */
-class PowerPolicy_Imx8_Fixed : public PowerPolicy
+class PowerPolicy_Imx8_Fixed : public PmPowerPolicy
 {
-private:
-    PowerManager pm{};
-
 public:
     /** *_freq_i - integer, range <0,3> */
     PowerPolicy_Imx8_Fixed(const std::string& a53_freq_i, const std::string& a72_freq_i)

--- a/src/power_policy/imx8_per_process.hpp
+++ b/src/power_policy/imx8_per_process.hpp
@@ -9,10 +9,9 @@
  *
  * NOTE: this is a test power policy, the error messages are not very helpful
  */
-class PowerPolicy_Imx8_PerProcess : public PowerPolicy
+class PowerPolicy_Imx8_PerProcess : public PmPowerPolicy
 {
 private:
-    PowerManager pm{};
     CpufreqPolicy &a53_pol;
     CpufreqPolicy &a72_pol;
     const cpu_set a53_cpus{0b001111};

--- a/src/power_policy/imx8_per_process.hpp
+++ b/src/power_policy/imx8_per_process.hpp
@@ -55,6 +55,7 @@ public:
             }
         }
     }
+    bool supports_per_process_frequencies() override { return true; }
 
 
     void on_process_start(Process &proc) override

--- a/src/power_policy/imx8_per_process.hpp
+++ b/src/power_policy/imx8_per_process.hpp
@@ -36,11 +36,11 @@ public:
         // check if the process is requesting any specific frequency and
         //  if its current cpuset intersects with the A53/A72 cluster
         cpu_set proc_cpus = proc.part.current_cpus;
-        if (proc.a53_freq_i && proc_cpus & a53_cpus) {
-            a53_pol.write_frequency_i(proc.a53_freq_i.value());
+        if (proc.a53_freq && proc_cpus & a53_cpus) {
+            a53_pol.write_frequency(proc.a53_freq.value());
         }
-        if (proc.a72_freq_i && proc_cpus & a72_cpus) {
-            a72_pol.write_frequency_i(proc.a72_freq_i.value());
+        if (proc.a72_freq && proc_cpus & a72_cpus) {
+            a72_pol.write_frequency(proc.a72_freq.value());
         }
     }
 };

--- a/src/power_policy/imx8_per_process.hpp
+++ b/src/power_policy/imx8_per_process.hpp
@@ -43,7 +43,7 @@ public:
         ASSERT(proc.requested_frequencies.size() == policies.size());
         // check if the process is requesting any specific frequency and
         //  if its current cpuset intersects with the A53/A72 cluster
-        cpu_set proc_cpus = proc.part.current_cpus;
+        const cpu_set &proc_cpus = proc.part.current_cpus();
 
         for (size_t i = 0; i < policies.size(); i++) {
             auto &policy = *policies[i];

--- a/src/power_policy/imx8_per_process.hpp
+++ b/src/power_policy/imx8_per_process.hpp
@@ -3,6 +3,7 @@
 #include "_power_policy.hpp"
 #include "power_manager.hpp"
 #include "window.hpp"
+#include <algorithm>            // TODO: Move to .cpp
 
 /**
  * Set frequency based on the currently executing process.
@@ -18,69 +19,54 @@
 class PowerPolicy_Imx8_PerProcess : public PmPowerPolicy
 {
 private:
+    struct CpuCluster {
+        CpufreqPolicy& cf_policy;
+        std::vector<Process *> requesting_procs {};
+        CpuCluster(CpufreqPolicy& cp) : cf_policy(cp) {}
+    };
     // currently, this is hardcoded for i.MX8, but should be quite simply extensible
     //  for other CPU cluster layouts
-    std::array<CpufreqPolicy *, 2> policies{ &pm.get_policy("policy0"), &pm.get_policy("policy4") };
-    // a list of currently running processes which requested a fixed frequency
-    // there may be multiple processes which requested the same frequency,
-    //  which is why a list is used instead of a single pointer
-    std::array<std::vector<Process *>, 2> locking_process_for_policy{};
+    std::array<CpuCluster, 2> clusters { pm.get_policy("policy0"), pm.get_policy("policy4") };
 
 public:
     PowerPolicy_Imx8_PerProcess()
     {
-        ASSERT(policies.size() == locking_process_for_policy.size());
-        for (auto &p : pm.policy_iter()) {
-            if (!p.available_frequencies) {
+        for (auto &p : pm.policy_iter())
+            if (!p.available_frequencies)
                 throw runtime_error("Cannot list available frequencies for the CPU"
                                     " - are you sure you're running DEmOS on an i.MX8?");
-            }
-        }
     }
 
     void on_process_start(Process &proc) override
     {
-        ASSERT(proc.requested_frequencies.size() == policies.size());
-        // check if the process is requesting any specific frequency and
-        //  if its current cpuset intersects with the A53/A72 cluster
-        const cpu_set &proc_cpus = proc.part.current_cpus();
-
-        for (size_t i = 0; i < policies.size(); i++) {
-            auto &policy = *policies[i];
-            auto &locking_processes = locking_process_for_policy[i];
-            auto requested_freq = proc.requested_frequencies[i];
-
-            if (requested_freq && proc_cpus & policy.affected_cores) {
+        for (CpuCluster &cc : clusters) {
+            if (proc.requested_frequency &&
+                proc.part.current_cpus() & cc.cf_policy.affected_cores) {
                 // process is requesting a fixed frequency, check if it is
                 //  compatible with existing locks; all locking processes must have requested the
                 //  same frequency, so it suffices to check the first one
-                if (!locking_processes.empty() &&
-                    locking_processes[0]->requested_frequencies[i] != requested_freq) {
+                if (!cc.requesting_procs.empty() &&
+                    cc.requesting_procs[0]->requested_frequency != proc.requested_frequency) {
                     throw std::runtime_error(
-                      fmt::format("Scheduled processes require different frequencies on the CPU "
-                                  "cluster '#{}': '{}', '{}' (process 1: '{}', process 2: '{}')",
-                                  i,
-                                  locking_processes[0]->requested_frequencies[i].value(),
-                                  requested_freq.value(),
-                                  locking_processes[0]->argv,
+                      fmt::format("Scheduled processes require different frequencies on the CPU(s) "
+                                  "{}: '{}', '{}' (process 1: '{}', process 2: '{}')",
+                                  cc.cf_policy.affected_cores.as_list(),
+                                  cc.requesting_procs[0]->requested_frequency.value(),
+                                  proc.requested_frequency.value(),
+                                  cc.requesting_procs[0]->argv,
                                   proc.argv));
                 }
-                locking_processes.push_back(&proc);
-                policy.write_frequency(requested_freq.value());
+                cc.requesting_procs.push_back(&proc);
+                cc.cf_policy.write_frequency(proc.requested_frequency.value());
             }
         }
     }
 
     void on_process_end(Process &process) override
     {
-        // remove the process from the list of locking processes
-        for (auto &lp : locking_process_for_policy) {
-            for (auto it = lp.begin(); it != lp.end(); it++) {
-                if (*it == &process) {
-                    lp.erase(it);
-                    break;
-                }
-            }
-        }
+	for (auto &cc : clusters) {
+	    auto deleted = std::remove(begin(cc.requesting_procs), end(cc.requesting_procs), &process);
+	    cc.requesting_procs.erase(deleted, end(cc.requesting_procs));
+	}
     }
 };

--- a/src/power_policy/imx8_per_process.hpp
+++ b/src/power_policy/imx8_per_process.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "_power_policy.hpp"
+#include "power_manager.hpp"
+#include "window.hpp"
+
+/**
+ * Set frequency based on the currently executing process.
+ *
+ * NOTE: this is a test power policy, the error messages are not very helpful
+ */
+class PowerPolicy_Imx8_PerProcess : public PowerPolicy
+{
+private:
+    PowerManager pm{};
+    CpufreqPolicy &a53_pol;
+    CpufreqPolicy &a72_pol;
+
+public:
+    PowerPolicy_Imx8_PerProcess()
+        : a53_pol{ pm.get_policy("policy0") }
+        , a72_pol{ pm.get_policy("policy4") }
+    {
+        for (auto &p : pm.policy_iter()) {
+            if (!p.available_frequencies) {
+                throw runtime_error("Cannot list available frequencies for the CPU"
+                                    " - are you sure you're running DEmOS on an i.MX8?");
+            }
+        }
+    }
+
+    void on_process_start(Process &proc) override
+    {
+        // TODO: better bound checking
+        if (proc.a53_freq_i) {
+            a53_pol.write_frequency(a53_pol.available_frequencies->at(proc.a53_freq_i.value()));
+        }
+        if (proc.a72_freq_i) {
+            a72_pol.write_frequency(a72_pol.available_frequencies->at(proc.a72_freq_i.value()));
+        }
+    }
+};

--- a/src/power_policy/imx8_per_process.hpp
+++ b/src/power_policy/imx8_per_process.hpp
@@ -7,21 +7,29 @@
 /**
  * Set frequency based on the currently executing process.
  *
- * NOTE: this is a test power policy, the error messages are not very helpful
+ * The requested frequencies for processes are validated at runtime, and when a collision
+ * occurs (multiple processes request different frequencies for the same CPU cluster), an
+ * error message is shown.
+ * Originally, an ahead-of-time collision algorithm was used, but it was quite complex,
+ * and a clean implementation required refactoring a significant part of the codebase
+ * (Config required access to PowerManager), which was deemed too time-intensive
+ * to implement for a single experimental feature.
  */
 class PowerPolicy_Imx8_PerProcess : public PmPowerPolicy
 {
 private:
-    CpufreqPolicy &a53_pol;
-    CpufreqPolicy &a72_pol;
-    const cpu_set a53_cpus{0b001111};
-    const cpu_set a72_cpus{0b110000};
+    // currently, this is hardcoded for i.MX8, but should be quite simply extensible
+    //  for other CPU cluster layouts
+    std::array<CpufreqPolicy *, 2> policies{ &pm.get_policy("policy0"), &pm.get_policy("policy4") };
+    // a list of currently running processes which requested a fixed frequency
+    // there may be multiple processes which requested the same frequency,
+    //  which is why a list is used instead of a single pointer
+    std::array<std::vector<Process *>, 2> locking_process_for_policy{};
 
 public:
     PowerPolicy_Imx8_PerProcess()
-        : a53_pol{ pm.get_policy("policy0") }
-        , a72_pol{ pm.get_policy("policy4") }
     {
+        ASSERT(policies.size() == locking_process_for_policy.size());
         for (auto &p : pm.policy_iter()) {
             if (!p.available_frequencies) {
                 throw runtime_error("Cannot list available frequencies for the CPU"
@@ -32,14 +40,44 @@ public:
 
     void on_process_start(Process &proc) override
     {
+        ASSERT(proc.requested_frequencies.size() == policies.size());
         // check if the process is requesting any specific frequency and
         //  if its current cpuset intersects with the A53/A72 cluster
         cpu_set proc_cpus = proc.part.current_cpus;
-        if (proc.a53_freq && proc_cpus & a53_cpus) {
-            a53_pol.write_frequency(proc.a53_freq.value());
+
+        for (size_t i = 0; i < policies.size(); i++) {
+            auto &policy = *policies[i];
+            auto &locking_processes = locking_process_for_policy[i];
+            auto requested_freq = proc.requested_frequencies[i];
+
+            if (requested_freq && proc_cpus & policy.affected_cores) {
+                // process is requesting a fixed frequency, check if it is
+                //  compatible with existing locks; all locking processes must have requested the
+                //  same frequency, so it suffices to check the first one
+                if (!locking_processes.empty() &&
+                    locking_processes[0]->requested_frequencies[i] != requested_freq) {
+                    throw std::runtime_error(
+                      fmt::format("Scheduled processes require different frequencies on the CPU "
+                                  "cluster '#{}': '{}', '{}'",
+                                  i,
+                                  locking_processes[0]->requested_frequencies[i].value(),
+                                  requested_freq.value()));
+                }
+                locking_processes.push_back(&proc);
+                policy.write_frequency(requested_freq.value());
+            }
         }
-        if (proc.a72_freq && proc_cpus & a72_cpus) {
-            a72_pol.write_frequency(proc.a72_freq.value());
+    }
+
+    void on_process_end(Process &process) override {
+        // remove the process from the list of locking processes
+        for (auto &lp : locking_process_for_policy) {
+            for (auto it = lp.begin(); it != lp.end(); it++) {
+                if (*it == &process) {
+                    lp.erase(it);
+                    break;
+                }
+            }
         }
     }
 };

--- a/src/power_policy/imx8_per_process.hpp
+++ b/src/power_policy/imx8_per_process.hpp
@@ -58,10 +58,12 @@ public:
                     locking_processes[0]->requested_frequencies[i] != requested_freq) {
                     throw std::runtime_error(
                       fmt::format("Scheduled processes require different frequencies on the CPU "
-                                  "cluster '#{}': '{}', '{}'",
+                                  "cluster '#{}': '{}', '{}' (process 1: '{}', process 2: '{}')",
                                   i,
                                   locking_processes[0]->requested_frequencies[i].value(),
-                                  requested_freq.value()));
+                                  requested_freq.value(),
+                                  locking_processes[0]->argv,
+                                  proc.argv));
                 }
                 locking_processes.push_back(&proc);
                 policy.write_frequency(requested_freq.value());
@@ -69,7 +71,8 @@ public:
         }
     }
 
-    void on_process_end(Process &process) override {
+    void on_process_end(Process &process) override
+    {
         // remove the process from the list of locking processes
         for (auto &lp : locking_process_for_policy) {
             for (auto it = lp.begin(); it != lp.end(); it++) {

--- a/src/power_policy/imx8_per_slice.hpp
+++ b/src/power_policy/imx8_per_slice.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "_power_policy.hpp"
+#include "power_manager.hpp"
+#include "slice.hpp"
+#include <optional>
+
+/**
+ * Set frequency based on the currently executing slice.
+ *
+ * The requested frequencies for slices are validated at runtime, and when a collision
+ * occurs (multiple slicees request different frequencies for the same CPU cluster), an
+ * error message is shown.
+ */
+class PowerPolicy_Imx8_PerSlice : public PmPowerPolicy
+{
+private:
+    // currently, this is hardcoded for i.MX8, but should be quite simply extensible
+    //  for other CPU cluster layouts
+    std::array<CpufreqPolicy *, 2> policies{ &pm.get_policy("policy0"), &pm.get_policy("policy4") };
+
+public:
+    PowerPolicy_Imx8_PerSlice()
+    {
+        for (auto &p : pm.policy_iter())
+            if (!p.available_frequencies)
+                throw runtime_error("Cannot list available frequencies for the CPU"
+                                    " - are you sure you're running DEmOS on an i.MX8?");
+    }
+
+    // Validate that the requested frequencies are available
+    void validate(const Windows &windows) override
+    {
+        for (const Window &win : windows) {
+            for (const Slice &slice : win.slices) {
+                if (!slice.requested_frequency) continue;
+                for (const CpufreqPolicy *policy : policies) {
+                    if (!(slice.cpus & policy->affected_cores)) continue;
+                    policy->validate_frequency(slice.requested_frequency.value());
+                }
+            }
+        }
+    }
+    bool supports_per_slice_frequencies() override { return true; }
+
+
+    void on_window_start(Window &win) override
+    {
+        for (CpufreqPolicy *cp : policies) {
+            std::optional<CpuFrequencyHz> freq = std::nullopt;
+            for (const Slice &slice : win.slices) {
+                if (slice.requested_frequency && slice.cpus & cp->affected_cores) {
+                    // slice is requesting a fixed frequency, check that all slices on the
+                    // same CPU cluster request the same frequency.
+                    if (freq.has_value() && freq.value() != slice.requested_frequency) {
+                        throw std::runtime_error(fmt::format(
+                          "Scheduled slices require different frequencies on the CPU(s) "
+                          "{}: '{}', '{}'",
+                          cp->affected_cores.as_list(),
+                          freq.value(),
+                          slice.requested_frequency.value()));
+                    }
+                    freq = slice.requested_frequency;
+                }
+            }
+            if (freq.has_value()) cp->write_frequency(freq.value());
+        }
+    }
+};

--- a/src/power_policy/low.hpp
+++ b/src/power_policy/low.hpp
@@ -3,11 +3,8 @@
 #include "_power_policy.hpp"
 #include "power_manager.hpp"
 
-class PowerPolicy_FixedLow : public PowerPolicy
+class PowerPolicy_FixedLow : public PmPowerPolicy
 {
-private:
-    PowerManager pm{};
-
 public:
     PowerPolicy_FixedLow()
     {

--- a/src/power_policy/minbe.hpp
+++ b/src/power_policy/minbe.hpp
@@ -3,11 +3,8 @@
 #include "_power_policy.hpp"
 #include "power_manager.hpp"
 
-class PowerPolicy_MinBE : public PowerPolicy
+class PowerPolicy_MinBE : public PmPowerPolicy
 {
-private:
-    PowerManager pm{};
-
 public:
     PowerPolicy_MinBE()
     {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -23,8 +23,12 @@ Process::Process(ev::loop_ref loop,
                  std::optional<std::filesystem::path> working_dir,
                  milliseconds budget,
                  milliseconds budget_jitter,
+                 std::optional<unsigned int> a53_freq,
+                 std::optional<unsigned int> a72_freq,
                  bool has_initialization)
     : part(partition)
+    , a53_freq_i{a53_freq}
+    , a72_freq_i{a72_freq}
     // budget +- (jitter / 2)
     , jitter_distribution_ms(-budget_jitter.count() / 2, budget_jitter.count() - budget_jitter.count() / 2)
     , loop(loop)

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -23,11 +23,10 @@ Process::Process(ev::loop_ref loop,
                  std::optional<std::filesystem::path> working_dir,
                  milliseconds budget,
                  milliseconds budget_jitter,
-                 std::optional<CpuFrequencyHz> a53_freq,
-                 std::optional<CpuFrequencyHz> a72_freq,
+                 std::optional<CpuFrequencyHz> req_freq,
                  bool has_initialization)
     : part(partition)
-    , requested_frequencies{ a53_freq, a72_freq }
+    , requested_frequency(req_freq)
     , argv(std::move(argv))
     // budget +- (jitter / 2)
     , jitter_distribution_ms(-budget_jitter.count() / 2,

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -23,14 +23,15 @@ Process::Process(ev::loop_ref loop,
                  std::optional<std::filesystem::path> working_dir,
                  milliseconds budget,
                  milliseconds budget_jitter,
-                 std::optional<unsigned int> a53_freq,
-                 std::optional<unsigned int> a72_freq,
+                 std::optional<CpuFrequencyHz> a53_freq,
+                 std::optional<CpuFrequencyHz> a72_freq,
                  bool has_initialization)
     : part(partition)
     , a53_freq{ a53_freq }
     , a72_freq{ a72_freq }
     // budget +- (jitter / 2)
-    , jitter_distribution_ms(-budget_jitter.count() / 2, budget_jitter.count() - budget_jitter.count() / 2)
+    , jitter_distribution_ms(-budget_jitter.count() / 2,
+                             budget_jitter.count() - budget_jitter.count() / 2)
     , loop(loop)
     , efd_continue(CHECK(eventfd(0, EFD_SEMAPHORE)))
     , cge(loop,
@@ -77,7 +78,8 @@ void Process::exec()
         // END CHILD PROCESS
     } else {
         // PARENT PROCESS
-        logger_process->debug("Running '{}' as PID '{}' (partition '{}')", argv, pid, part.get_name());
+        logger_process->debug(
+          "Running '{}' as PID '{}' (partition '{}')", argv, pid, part.get_name());
         child_w.start(pid, 0);
         // TODO: shouldn't we do this in the child process, so that we know the process
         //  is frozen before we start the command? as it is now, I think there's a possible
@@ -165,7 +167,8 @@ void Process::set_remaining_budget(milliseconds next_budget)
     ASSERT(next_budget > next_budget.zero());
     ASSERT(next_budget < budget);
     actual_budget = next_budget;
-    TRACE_PROCESS("Next budget for process '{}' shortened to '{} milliseconds'.", pid, next_budget.count());
+    TRACE_PROCESS(
+      "Next budget for process '{}' shortened to '{} milliseconds'.", pid, next_budget.count());
 }
 
 void Process::reset_budget()

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -27,8 +27,8 @@ Process::Process(ev::loop_ref loop,
                  std::optional<unsigned int> a72_freq,
                  bool has_initialization)
     : part(partition)
-    , a53_freq_i{a53_freq}
-    , a72_freq_i{a72_freq}
+    , a53_freq{ a53_freq }
+    , a72_freq{ a72_freq }
     // budget +- (jitter / 2)
     , jitter_distribution_ms(-budget_jitter.count() / 2, budget_jitter.count() - budget_jitter.count() / 2)
     , loop(loop)

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -24,11 +24,11 @@ Process::Process(ev::loop_ref loop,
                  milliseconds budget,
                  milliseconds budget_jitter,
                  bool has_initialization)
+    : part(partition)
     // budget +- (jitter / 2)
-    : jitter_distribution_ms(-budget_jitter.count() / 2, budget_jitter.count() - budget_jitter.count() / 2)
+    , jitter_distribution_ms(-budget_jitter.count() / 2, budget_jitter.count() - budget_jitter.count() / 2)
     , loop(loop)
     , efd_continue(CHECK(eventfd(0, EFD_SEMAPHORE)))
-    , part(partition)
     , cge(loop,
           partition.cge,
           name,

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -27,8 +27,7 @@ Process::Process(ev::loop_ref loop,
                  std::optional<CpuFrequencyHz> a72_freq,
                  bool has_initialization)
     : part(partition)
-    , a53_freq{ a53_freq }
-    , a72_freq{ a72_freq }
+    , requested_frequencies{ a53_freq, a72_freq }
     // budget +- (jitter / 2)
     , jitter_distribution_ms(-budget_jitter.count() / 2,
                              budget_jitter.count() - budget_jitter.count() / 2)

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -28,6 +28,7 @@ Process::Process(ev::loop_ref loop,
                  bool has_initialization)
     : part(partition)
     , requested_frequencies{ a53_freq, a72_freq }
+    , argv(std::move(argv))
     // budget +- (jitter / 2)
     , jitter_distribution_ms(-budget_jitter.count() / 2,
                              budget_jitter.count() - budget_jitter.count() / 2)
@@ -38,7 +39,6 @@ Process::Process(ev::loop_ref loop,
           name,
           std::bind(&Process::populated_cb, this, _1)) // NOLINT(modernize-avoid-bind)
     , cgf(partition.cgf, name)
-    , argv(std::move(argv))
     , working_dir(std::move(working_dir))
     , budget(budget)
     , actual_budget(budget)

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -80,8 +80,7 @@ public:
     void mark_uncompleted();
 
     Partition &part;
-    const std::optional<CpuFrequencyHz> a53_freq;
-    const std::optional<CpuFrequencyHz> a72_freq;
+    const std::array<std::optional<CpuFrequencyHz>, 2> requested_frequencies;
 
 private:
     std::uniform_int_distribution<long> jitter_distribution_ms;

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -76,6 +76,8 @@ public:
     void mark_completed();
     void mark_uncompleted();
 
+    Partition &part;
+
 private:
     std::uniform_int_distribution<long> jitter_distribution_ms;
 
@@ -84,7 +86,6 @@ private:
     ev::child child_w{ loop };
     int efd_continue; // new period eventfd
 
-    Partition &part;
     CgroupEvents cge;
     CgroupFreezer cgf;
 

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -4,14 +4,14 @@
 #include <fcntl.h>
 #include <filesystem>
 #include <iostream>
+#include <random>
 #include <unistd.h>
 #include <vector>
-#include <random>
 
 #include "cgroup.hpp"
+#include "cpufreq_policy.hpp"
 #include "evfd.hpp"
 #include "timerfd.hpp"
-#include "cpufreq_policy.hpp"
 
 class Partition;
 
@@ -81,6 +81,7 @@ public:
 
     Partition &part;
     const std::array<std::optional<CpuFrequencyHz>, 2> requested_frequencies;
+    const std::string argv;
 
 private:
     std::uniform_int_distribution<long> jitter_distribution_ms;
@@ -93,7 +94,6 @@ private:
     CgroupEvents cge;
     CgroupFreezer cgf;
 
-    const std::string argv;
     const std::optional<std::filesystem::path> working_dir;
     const std::chrono::milliseconds budget;
     std::chrono::milliseconds actual_budget;

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -79,8 +79,8 @@ public:
     void mark_uncompleted();
 
     Partition &part;
-    const std::optional<unsigned int> a53_freq_i;
-    const std::optional<unsigned int> a72_freq_i;
+    const std::optional<unsigned int> a53_freq;
+    const std::optional<unsigned int> a72_freq;
 
 private:
     std::uniform_int_distribution<long> jitter_distribution_ms;

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -11,6 +11,7 @@
 #include "cgroup.hpp"
 #include "evfd.hpp"
 #include "timerfd.hpp"
+#include "cpufreq_policy.hpp"
 
 class Partition;
 
@@ -32,8 +33,8 @@ public:
             std::optional<std::filesystem::path> working_dir,
             std::chrono::milliseconds budget,
             std::chrono::milliseconds budget_jitter,
-            std::optional<unsigned int> a53_freq,
-            std::optional<unsigned int> a72_freq,
+            std::optional<CpuFrequencyHz> a53_freq,
+            std::optional<CpuFrequencyHz> a72_freq,
             bool has_initialization = false);
 
     /** Spawns the underlying system process. */
@@ -79,8 +80,8 @@ public:
     void mark_uncompleted();
 
     Partition &part;
-    const std::optional<unsigned int> a53_freq;
-    const std::optional<unsigned int> a72_freq;
+    const std::optional<CpuFrequencyHz> a53_freq;
+    const std::optional<CpuFrequencyHz> a72_freq;
 
 private:
     std::uniform_int_distribution<long> jitter_distribution_ms;

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -33,8 +33,7 @@ public:
             std::optional<std::filesystem::path> working_dir,
             std::chrono::milliseconds budget,
             std::chrono::milliseconds budget_jitter,
-            std::optional<CpuFrequencyHz> a53_freq,
-            std::optional<CpuFrequencyHz> a72_freq,
+            std::optional<CpuFrequencyHz> req_freq,
             bool has_initialization = false);
 
     /** Spawns the underlying system process. */
@@ -80,7 +79,7 @@ public:
     void mark_uncompleted();
 
     Partition &part;
-    const std::array<std::optional<CpuFrequencyHz>, 2> requested_frequencies;
+    const std::optional<CpuFrequencyHz> requested_frequency;
     const std::string argv;
 
 private:

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -32,6 +32,8 @@ public:
             std::optional<std::filesystem::path> working_dir,
             std::chrono::milliseconds budget,
             std::chrono::milliseconds budget_jitter,
+            std::optional<unsigned int> a53_freq,
+            std::optional<unsigned int> a72_freq,
             bool has_initialization = false);
 
     /** Spawns the underlying system process. */
@@ -77,6 +79,8 @@ public:
     void mark_uncompleted();
 
     Partition &part;
+    const std::optional<unsigned int> a53_freq_i;
+    const std::optional<unsigned int> a72_freq_i;
 
 private:
     std::uniform_int_distribution<long> jitter_distribution_ms;

--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -16,10 +16,12 @@ Slice::Slice(ev::loop_ref loop,
              std::function<void(Slice &, time_point)> sc_done_cb,
              Partition *sc,
              Partition *be,
+             std::optional<CpuFrequencyHz> req_freq,
              cpu_set cpus)
     : sc(sc)
     , be(be)
     , cpus(std::move(cpus))
+    , requested_frequency(req_freq)
     , power_policy{ power_policy }
     , sc_done_cb(std::move(sc_done_cb))
     , timer(loop)

--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -1,5 +1,6 @@
 #include "slice.hpp"
 #include "log.hpp"
+#include "power_policy/_power_policy.hpp"
 #include <lib/assert.hpp>
 
 /*

--- a/src/slice.hpp
+++ b/src/slice.hpp
@@ -2,6 +2,7 @@
 
 #include "lib/cpu_set.hpp"
 #include "partition.hpp"
+#include "power_policy/_power_policy.hpp"
 #include "timerfd.hpp"
 #include <chrono>
 #include <ev++.h>
@@ -23,6 +24,7 @@ class Slice
 {
 public:
     Slice(ev::loop_ref loop,
+          PowerPolicy &power_policy,
           std::function<void(Slice &, time_point)> sc_done_cb,
           Partition *sc,
           Partition *be,
@@ -48,6 +50,7 @@ public:
     void stop(time_point current_time);
 
 private:
+    PowerPolicy &power_policy;
     std::function<void(Slice &, time_point)> sc_done_cb;
     Process *running_process = nullptr;
     Partition *running_partition = nullptr;

--- a/src/slice.hpp
+++ b/src/slice.hpp
@@ -2,11 +2,12 @@
 
 #include "lib/cpu_set.hpp"
 #include "partition.hpp"
-#include "power_policy/_power_policy.hpp"
 #include "timerfd.hpp"
 #include <chrono>
 #include <ev++.h>
 #include <functional>
+
+class PowerPolicy;
 
 using time_point = std::chrono::steady_clock::time_point;
 

--- a/src/slice.hpp
+++ b/src/slice.hpp
@@ -62,7 +62,7 @@ private:
 
     void schedule_next(time_point current_time);
     void start_partition(Partition *part, time_point current_time, bool move_to_first_proc);
-    void stop_current_process();
+    void stop_current_process(bool mark_completed = true);
     bool load_next_process(time_point current_time);
     void start_next_process(time_point current_time);
 };

--- a/src/slice.hpp
+++ b/src/slice.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "cpufreq_policy.hpp"
 #include "lib/cpu_set.hpp"
 #include "partition.hpp"
 #include "timerfd.hpp"
@@ -29,6 +30,7 @@ public:
           std::function<void(Slice &, time_point)> sc_done_cb,
           Partition *sc,
           Partition *be,
+          std::optional<CpuFrequencyHz> req_freq,
           cpu_set cpus = cpu_set(0x1));
 
     Slice(const Slice &) = delete;
@@ -40,6 +42,8 @@ public:
     /** Best-effort partition running in this slice. */
     Partition *const be;
     const cpu_set cpus;
+    const std::optional<CpuFrequencyHz> requested_frequency;
+
 
     /**
      * Starts execution of SC partition, if present. Calls sc_done_cb

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1,5 +1,6 @@
 #include "window.hpp"
 #include "log.hpp"
+#include "power_policy/_power_policy.hpp"
 
 Window::Window(ev::loop_ref loop_, std::chrono::milliseconds length_, PowerPolicy &power_policy)
     : loop(loop_)

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -59,6 +59,8 @@ void Window::slice_sc_end_cb([[maybe_unused]] Slice &slice, time_point current_t
     }
 
     // option 1) run BE immediately after SC
+    // per-process frequency validation currently assumes option 2) here,
+    //  doesn't work correctly with option 1)
     // slice->start_be(current_time);
 
     // option 2) wait until all SC partitions finish

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -8,10 +8,10 @@ Window::Window(ev::loop_ref loop_, std::chrono::milliseconds length_, PowerPolic
     , length(length_)
 {}
 
-Slice &Window::add_slice(Partition *sc, Partition *be, const cpu_set &cpus)
+Slice &Window::add_slice(Partition *sc, Partition *be, const cpu_set &cpus, std::optional<CpuFrequencyHz> req_freq)
 {
     auto sc_cb = [this](Slice &s, time_point t) { slice_sc_end_cb(s, t); };
-    return slices.emplace_back(loop, power_policy, sc_cb, sc, be, cpus);
+    return slices.emplace_back(loop, power_policy, sc_cb, sc, be, req_freq, cpus);
 }
 
 bool Window::has_sc_finished() const

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -10,7 +10,7 @@ Window::Window(ev::loop_ref loop_, std::chrono::milliseconds length_, PowerPolic
 Slice &Window::add_slice(Partition *sc, Partition *be, const cpu_set &cpus)
 {
     auto sc_cb = [this](Slice &s, time_point t) { slice_sc_end_cb(s, t); };
-    return slices.emplace_back(loop, sc_cb, sc, be, cpus);
+    return slices.emplace_back(loop, power_policy, sc_cb, sc, be, cpus);
 }
 
 bool Window::has_sc_finished() const

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <ev++.h>
 #include <list>
+#include <optional>
 
 class Window;
 class PowerPolicy;
@@ -30,7 +31,7 @@ public:
 
     Window(ev::loop_ref loop, std::chrono::milliseconds length, PowerPolicy &power_policy);
 
-    Slice &add_slice(Partition *sc, Partition *be, const cpu_set &cpus);
+    Slice &add_slice(Partition *sc, Partition *be, const cpu_set &cpus, std::optional<CpuFrequencyHz> req_freq);
     [[nodiscard]] bool has_sc_finished() const;
     void start(time_point current_time);
     void stop(time_point current_time);

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "power_policy/_power_policy.hpp"
 #include "slice.hpp"
 #include <chrono>
 #include <ev++.h>
 #include <list>
 
 class Window;
+class PowerPolicy;
 
 using Windows = std::list<Window>;
 using time_point = std::chrono::steady_clock::time_point;

--- a/test/0200-config.t
+++ b/test/0200-config.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 . testlib
-plan_tests 21
+plan_tests 20
 
 # set fixed log level for config tests; otherwise if user would run something
 #  like `SPDLOG_LEVEL=trace make test`, the output would include the logs and the tests would fail
@@ -41,12 +41,6 @@ out=$(demos-sched -C "{
     partitions: [ {name: SC, processes: [{cmd: echo, budget: 100, jitter: 250}]} ]
 }" 2>&1)
 is $? 1 "'jitter > 2 * budget' causes an error"
-
-out=$(demos-sched -C "{
-    windows: [ {length: 500, sc_partition: SC} ],
-    partitions: [ {name: SC, processes: [{cmd: echo, budget: 50, _a53_freq: 10}]} ]
-}" 2>&1)
-is $? 1 "CPU frequency out of range <0, 3> causes an error"
 
 test_normalization "missing slice definition" \
 "{

--- a/test/0200-config.t
+++ b/test/0200-config.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 . testlib
-plan_tests 20
+plan_tests 21
 
 # set fixed log level for config tests; otherwise if user would run something
 #  like `SPDLOG_LEVEL=trace make test`, the output would include the logs and the tests would fail
@@ -41,6 +41,12 @@ out=$(demos-sched -C "{
     partitions: [ {name: SC, processes: [{cmd: echo, budget: 100, jitter: 250}]} ]
 }" 2>&1)
 is $? 1 "'jitter > 2 * budget' causes an error"
+
+out=$(demos-sched -C "{
+    windows: [ {length: 500, sc_partition: SC} ],
+    partitions: [ {name: SC, processes: [{cmd: echo, budget: 50, _a53_freq: 10}]} ]
+}" 2>&1)
+is $? 1 "CPU frequency out of range <0, 3> causes an error"
 
 test_normalization "missing slice definition" \
 "{

--- a/test/0210-config_validation.t
+++ b/test/0210-config_validation.t
@@ -53,8 +53,8 @@ test_validation_fail "unfeasible per-process freq combination - A53" "{
             {cpu: 1, sc_partition: SC2},]}
     ],
     partitions: [
-        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 1}]},
-        {name: SC2, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
+        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 896}]},
+        {name: SC2, processes: [{cmd: echo, budget: 1, _a53_freq: 600}]},
     ],
 }" "window #0, between SC partitions on CPU cluster '0-3'."
 
@@ -65,8 +65,8 @@ test_validation_fail "unfeasible per-process freq combination - A72" "{
             {cpu: 5, sc_partition: SC2},]}
     ],
     partitions: [
-        {name: SC1, processes: [{cmd: echo, budget: 1, _a72_freq: 1}]},
-        {name: SC2, processes: [{cmd: echo, budget: 1, _a72_freq: 0}]},
+        {name: SC1, processes: [{cmd: echo, budget: 1, _a72_freq: 1056}]},
+        {name: SC2, processes: [{cmd: echo, budget: 1, _a72_freq: 600}]},
     ],
 }" "window #0, between SC partitions on CPU cluster '4,5'."
 
@@ -77,8 +77,8 @@ test_validation_fail "unfeasible per-process freq combination - BE" "{
             {cpu: 1, be_partition: BE2},]}
     ],
     partitions: [
-        {name: BE1, processes: [{cmd: echo, budget: 1, _a53_freq: 1}]},
-        {name: BE2, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
+        {name: BE1, processes: [{cmd: echo, budget: 1, _a53_freq: 896}]},
+        {name: BE2, processes: [{cmd: echo, budget: 1, _a53_freq: 600}]},
     ],
 }" "window #0, between BE partitions on CPU cluster '0-3'."
 
@@ -89,8 +89,8 @@ test_validation_pass "collision between SC and BE is ignored" "{
             {cpu: 1, be_partition: BE1},]}
     ],
     partitions: [
-        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
-        {name: BE1, processes: [{cmd: echo, budget: 1, _a53_freq: 1}]},
+        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 896}]},
+        {name: BE1, processes: [{cmd: echo, budget: 1, _a53_freq: 600}]},
     ],
 }"
 
@@ -100,8 +100,8 @@ test_validation_pass "single partition requesting multiple freqs is feasible" "{
     ],
     partitions: [
         {name: SC1, processes: [
-            {cmd: echo, budget: 1, _a53_freq: 0},
-            {cmd: echo, budget: 1, _a53_freq: 1},
+            {cmd: echo, budget: 1, _a53_freq: 896},
+            {cmd: echo, budget: 1, _a53_freq: 600},
         ]}
     ],
 }"
@@ -114,8 +114,8 @@ test_validation_pass "same frequency from multiple partitions is feasible" "{
         ]}
     ],
     partitions: [
-        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
-        {name: SC2, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
+        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 600}]},
+        {name: SC2, processes: [{cmd: echo, budget: 1, _a53_freq: 600}]},
     ],
 }"
 
@@ -127,7 +127,7 @@ test_validation_pass "freqs on different clusters are feasible" "{
         ]}
     ],
     partitions: [
-        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
-        {name: SC2, processes: [{cmd: echo, budget: 1, _a72_freq: 1}]},
+        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 600}]},
+        {name: SC2, processes: [{cmd: echo, budget: 1, _a72_freq: 1056}]},
     ],
 }"

--- a/test/0210-config_validation.t
+++ b/test/0210-config_validation.t
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+. testlib
+plan_tests 14
+
+# set fixed log level for config tests; otherwise if user would run something
+#  like `SPDLOG_LEVEL=trace make test`, the output would include the logs and the tests would fail
+export SPDLOG_LEVEL=warning
+
+test_validation_pass() {
+    local test_name=$1
+    local cfg_in=$2
+
+    echo "======== NEXT TEST =======================" >&2
+    demos-sched -d -C "$cfg_in" >&2
+    is $? 0 "$1"
+}
+
+test_validation_fail() {
+    local test_name=$1
+    local cfg_in=$2
+    local error_like_expected=$3
+
+    local exit_code
+    local demos_output # `local` must be separate, otherwise it overwrites the exit code from DEmOS
+    echo "======== NEXT TEST =======================" >&2
+    demos_output=$(demos-sched -d -C "$cfg_in" 2>&1)
+    exit_code=$?
+    echo "$demos_output" >&2
+    is $exit_code 1 "$1 - DEmOS should exit with code 1"
+    like "$demos_output" "$error_like_expected" "$test_name - error output matches"
+}
+
+test_validation_fail "unknown partition" "{
+    windows: [{length: 1, cpu: 0, sc_partition: NON_EXISTENT}],
+    partitions: [],
+}" "unknown partition 'NON_EXISTENT'"
+
+test_validation_fail "overlapping CPU sets inside window" "{
+    windows: [{length: 1, slices: [
+        {cpu: 0, sc_partition: SC1},
+        {cpu: 0, sc_partition: SC2},
+    ]}],
+    partitions: [
+        {name: SC1, processes: {cmd: echo, budget: 1}},
+        {name: SC2, processes: {cmd: echo, budget: 1}},
+    ],
+}" "overlapping CPU sets"
+
+test_validation_fail "unfeasible per-process freq combination - A53" "{
+    windows: [
+        {length: 1, slices: [
+            {cpu: 0, sc_partition: SC1},
+            {cpu: 1, sc_partition: SC2},]}
+    ],
+    partitions: [
+        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 1}]},
+        {name: SC2, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
+    ],
+}" "window #0, between SC partitions on CPU cluster '0-3'."
+
+test_validation_fail "unfeasible per-process freq combination - A72" "{
+    windows: [
+        {length: 1, slices: [
+            {cpu: 4, sc_partition: SC1},
+            {cpu: 5, sc_partition: SC2},]}
+    ],
+    partitions: [
+        {name: SC1, processes: [{cmd: echo, budget: 1, _a72_freq: 1}]},
+        {name: SC2, processes: [{cmd: echo, budget: 1, _a72_freq: 0}]},
+    ],
+}" "window #0, between SC partitions on CPU cluster '4,5'."
+
+test_validation_fail "unfeasible per-process freq combination - BE" "{
+    windows: [
+        {length: 1, slices: [
+            {cpu: 0, be_partition: BE1},
+            {cpu: 1, be_partition: BE2},]}
+    ],
+    partitions: [
+        {name: BE1, processes: [{cmd: echo, budget: 1, _a53_freq: 1}]},
+        {name: BE2, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
+    ],
+}" "window #0, between BE partitions on CPU cluster '0-3'."
+
+test_validation_pass "collision between SC and BE is ignored" "{
+    windows: [
+        {length: 1, slices: [
+            {cpu: 0, sc_partition: SC1},
+            {cpu: 1, be_partition: BE1},]}
+    ],
+    partitions: [
+        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
+        {name: BE1, processes: [{cmd: echo, budget: 1, _a53_freq: 1}]},
+    ],
+}"
+
+test_validation_pass "single partition requesting multiple freqs is feasible" "{
+    windows: [
+        {length: 1, slices: [{cpu: 0, sc_partition: SC1}]}
+    ],
+    partitions: [
+        {name: SC1, processes: [
+            {cmd: echo, budget: 1, _a53_freq: 0},
+            {cmd: echo, budget: 1, _a53_freq: 1},
+        ]}
+    ],
+}"
+
+test_validation_pass "same frequency from multiple partitions is feasible" "{
+    windows: [
+        {length: 1, slices: [
+            {cpu: 0, be_partition: SC1},
+            {cpu: 1, be_partition: SC2},
+        ]}
+    ],
+    partitions: [
+        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
+        {name: SC2, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
+    ],
+}"
+
+test_validation_pass "freqs on different clusters are feasible" "{
+    windows: [
+        {length: 1, slices: [
+            {cpu: 0, be_partition: SC1},
+            {cpu: 4, be_partition: SC2},
+        ]}
+    ],
+    partitions: [
+        {name: SC1, processes: [{cmd: echo, budget: 1, _a53_freq: 0}]},
+        {name: SC2, processes: [{cmd: echo, budget: 1, _a72_freq: 1}]},
+    ],
+}"

--- a/test/meson.build
+++ b/test/meson.build
@@ -3,6 +3,7 @@ tests = '''
 0020-basic.t
 0100-api.t
 0200-config.t
+0210-config_validation.t
 '''.split()
 
 foreach t: tests

--- a/test_config/per_process_power_policy.yaml
+++ b/test_config/per_process_power_policy.yaml
@@ -1,0 +1,23 @@
+# tests the imx8_per_process power policy
+
+partitions:
+  - name: SC1
+    processes:
+      - cmd: echo proc00; sleep 3600
+        budget: 1000
+        _a53_freq: 0
+        _a72_freq: 0
+      - cmd: echo proc33; sleep 3600
+        budget: 1000
+        _a53_freq: 3
+        _a72_freq: 3
+      - cmd: echo proc12; sleep 3600
+        budget: 1000
+        _a53_freq: 1
+        _a72_freq: 2
+
+windows:
+  - length: 3000
+    slices:
+      - cpu: 0-1
+        sc_partition: SC1

--- a/test_config/per_process_power_policy.yaml
+++ b/test_config/per_process_power_policy.yaml
@@ -1,23 +1,27 @@
 # tests the imx8_per_process power policy
+# we currently don't have a good way to test this in the automated test suite
+
+# in the 1st window, the policy should only switch frequencies for the A53 cluster;
+# in the 2nd window, only for the A72 cluster
 
 partitions:
   - name: SC1
     processes:
-      - cmd: echo proc00; sleep 3600
-        budget: 1000
+      - cmd: echo proc0; sleep 3600
+        budget: 500
+        _a53_freq: 3
+        _a72_freq: 2
+      - cmd: echo proc1; sleep 3600
+        budget: 500
         _a53_freq: 0
         _a72_freq: 0
-      - cmd: echo proc33; sleep 3600
-        budget: 1000
-        _a53_freq: 3
-        _a72_freq: 3
-      - cmd: echo proc12; sleep 3600
-        budget: 1000
-        _a53_freq: 1
-        _a72_freq: 2
 
 windows:
-  - length: 3000
+  - length: 1500
     slices:
-      - cpu: 0-1
+      - cpu: 0
+        sc_partition: SC1
+  - length: 1500
+    slices:
+      - cpu: 4
         sc_partition: SC1

--- a/test_config/per_process_power_policy.yaml
+++ b/test_config/per_process_power_policy.yaml
@@ -9,19 +9,16 @@ partitions:
     processes:
       - cmd: echo proc0; sleep 3600
         budget: 500
-        _a53_freq: 1200
-        _a72_freq: 1296
+        frequency: 1200
+  - name: SC2
+    processes:
       - cmd: echo proc1; sleep 3600
         budget: 500
-        _a53_freq: 600
-        _a72_freq: 600
-
+        frequency: 600
 windows:
   - length: 1500
     slices:
       - cpu: 0
         sc_partition: SC1
-  - length: 1500
-    slices:
       - cpu: 4
-        sc_partition: SC1
+        be_partition: SC2

--- a/test_config/per_process_power_policy.yaml
+++ b/test_config/per_process_power_policy.yaml
@@ -9,12 +9,12 @@ partitions:
     processes:
       - cmd: echo proc0; sleep 3600
         budget: 500
-        _a53_freq: 3
-        _a72_freq: 2
+        _a53_freq: 1200
+        _a72_freq: 1296
       - cmd: echo proc1; sleep 3600
         budget: 500
-        _a53_freq: 0
-        _a72_freq: 0
+        _a53_freq: 600
+        _a72_freq: 600
 
 windows:
   - length: 1500

--- a/test_config/per_process_power_policy2.yaml
+++ b/test_config/per_process_power_policy2.yaml
@@ -1,0 +1,29 @@
+# tests the imx8_per_process power policy
+# we currently don't have a good way to test this in the automated
+# test suite
+
+partitions:
+  - name: SC1
+    processes:
+      - cmd: echo proc0; sleep 3600
+        budget: 500
+        frequency: 1200
+  - name: BE
+    processes:
+      - cmd: echo proc1; sleep 3600
+        budget: 1000
+        frequency: 600
+      - cmd: echo proc2; sleep 3600
+        budget: 1000
+        frequency: 1296
+windows:
+  - length: 1500
+    slices:
+      - cpu: 0
+        sc_partition: SC1
+      - cpu: 4
+        be_partition: BE
+  - length: 1500
+    slices:
+      - cpu: 4
+        be_partition: BE

--- a/test_config/per_slice_power_policy.yaml
+++ b/test_config/per_slice_power_policy.yaml
@@ -1,0 +1,31 @@
+# tests the imx8_per_slice power policy
+# we currently don't have a good way to test this in the automated
+# test suite
+
+partitions:
+  - name: SC1
+    processes:
+      - cmd: echo proc0; sleep 3600
+        budget: 500
+  - name: BE
+    processes:
+      - cmd: echo proc1; sleep 3600
+        budget: 1000
+      - cmd: echo proc2; sleep 3600
+        budget: 1000
+windows:
+  - length: 1500
+    slices:
+      - cpu: 0
+        sc_partition: SC1
+        frequency: 1200
+      - cpu: 4
+        be_partition: BE
+        frequency: 600
+  - length: 1500
+    slices:
+      - cpu: 0
+        frequency: 896
+      - cpu: 4
+        be_partition: BE
+        frequency: 1296


### PR DESCRIPTION
Currently, the policy and the config frequency parameters are not documented; I'll add the documentation when the interface is finalized. Other than that, this is ready for a review.

TODO: Figure out a good interface to set frequencies for the processes without explicitly-defined frequencies; currently, the last explicitly-set frequency is kept. This is efficient, as there aren't needless switches, but it is not very intuitive and all frequency changes must be set manually. Another possible solution could be to have a single fixed frequency for all other processes, or use the original idea of allowing an additional power policy, which only applies to the processes without an explicitly-set frequency.