### PR TITLE
Add platform-independent per-process power policy

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -69,7 +69,6 @@ static Node normalize_process(const Node &proc, float default_budget)
                 //  before freezing it and starting normal scheduling
                 norm_proc[k] = proc[k].as<bool>();
             } else if (k == "frequency") {
-                // TODO: when the interface is finalized, remove the leading underscore
                 norm_proc[k] = proc[k].as<unsigned int>();
             } else {
                 throw runtime_error("Unexpected config key: " + k);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -69,7 +69,7 @@ static Node normalize_process(const Node &proc, float default_budget)
                 //  before freezing it and starting normal scheduling
                 norm_proc[k] = proc[k].as<bool>();
             } else if (k == "frequency") {
-                norm_proc[k] = proc[k].as<unsigned int>();
+                norm_proc[k] = proc[k].as<double>();
             } else {
                 throw runtime_error("Unexpected config key: " + k);
             }
@@ -210,7 +210,7 @@ Node Config::normalize_slice(const Node &slice,
         if (k == "cpu")
             norm_slice[k] = slice[k].as<string>();
         else if (k == "frequency")
-            norm_slice[k] = slice[k].as<unsigned int>();
+            norm_slice[k] = slice[k].as<double>();
         else if (k == "sc_partition")
             // if process budget is not set, `0.6 * window length` is used as a default for SC
             //  partition; otherwise, SC partition would use up the whole budget, not leaving any
@@ -436,9 +436,9 @@ void Config::create_scheduler_objects(const CgroupConfig &c,
             auto budget = chrono::milliseconds(yprocess["budget"].as<int>());
             auto budget_jitter = chrono::milliseconds(yprocess["jitter"].as<int>());
             auto req_freq = yprocess["frequency"]
-                               ? std::optional(CpuFrequencyHz{
-                                   1000 * 1000 * yprocess["frequency"].as<unsigned int>() })
-                               : std::nullopt;
+                              ? std::optional(CpuFrequencyHz{ static_cast<uint64_t>(
+                                  1000 * 1000 * yprocess["frequency"].as<double>()) })
+                              : std::nullopt;
             if (req_freq && !c.power_policy.supports_per_process_frequencies() && !ppf_warned) {
                 logger->warn("Per-processes frequency specified in the configuration, but not supported by the power policy.");
                 ppf_warned = true;
@@ -502,11 +502,12 @@ void Config::create_scheduler_objects(const CgroupConfig &c,
             }
 
             auto req_freq = yslice["frequency"]
-                               ? std::optional(CpuFrequencyHz{
-                                   1000 * 1000 * yslice["frequency"].as<unsigned int>() })
-                               : std::nullopt;
+                              ? std::optional(CpuFrequencyHz{ static_cast<uint64_t>(
+                                  1000 * 1000 * yslice["frequency"].as<double>()) })
+                              : std::nullopt;
             if (req_freq && !c.power_policy.supports_per_slice_frequencies() && !ppf_warned) {
-                logger->warn("Per-slice frequency specified in the configuration, but not supported by the power policy.");
+                logger->warn("Per-slice frequency specified in the configuration, but not "
+                             "supported by the power policy.");
                 ppf_warned = true;
             }
 

--- a/src/cpufreq_policy.hpp
+++ b/src/cpufreq_policy.hpp
@@ -37,7 +37,7 @@ struct fmt::formatter<CpuFrequencyHz> : fmt::formatter<uint64_t>
     auto format(CpuFrequencyHz const &freq, FormatContext &ctx)
     {
         return fmt::format_to(
-          ctx.out(), "{}{} MHz", freq.freq % 1000000 == 0 ? "" : "~", freq.freq / 1000000);
+          ctx.out(), "{} MHz", freq.freq / 1000000.0);
     }
 };
 

--- a/src/cpufreq_policy.hpp
+++ b/src/cpufreq_policy.hpp
@@ -78,8 +78,8 @@ public: ////////////////////////////////////////////////////////////////////////
         , fd_freq{ -1 } // opened after governor is changed
         , name{ policy_dir.filename() }
         , original_governor{ current_governor }
-        , min_frequency{ read_freq_file(policy_dir / "scaling_min_freq") }
-        , max_frequency{ read_freq_file(policy_dir / "scaling_max_freq") }
+        , min_frequency{ read_freq_file(policy_dir / "cpuinfo_min_freq") }
+        , max_frequency{ read_freq_file(policy_dir / "cpuinfo_max_freq") }
         , available_frequencies{ read_available_frequencies() }
         , affected_cores{ read_affected_cpus() }
         // sometimes, the policy does not affect any cores (e.g. all controlled cores are offline);

--- a/src/power_policy/_power_policy.cpp
+++ b/src/power_policy/_power_policy.cpp
@@ -14,6 +14,7 @@
 #include "power_policy/low.hpp"
 #include "power_policy/minbe.hpp"
 #include "power_policy/none.hpp"
+#include "power_policy/per_process.hpp"
 
 
 // after multiple template-based attempts, a macro solution was chosen,
@@ -45,9 +46,10 @@ static const std::map<std::string,
       PP("minbe", PowerPolicy_MinBE, 0),
       PP("low", PowerPolicy_FixedLow, 0),
       PP("high", PowerPolicy_FixedHigh, 0),
+      PP("per_process", PowerPolicy_PerProcess, 0),
       PP("imx8_alternating", PowerPolicy_Imx8_Alternating, 4),
       PP("imx8_fixed", PowerPolicy_Imx8_Fixed, 2),
-      PP("imx8_per_process", PowerPolicy_Imx8_PerProcess, 0),
+      PP("imx8_per_process", PowerPolicy_Imx8_PerProcess, 0), // TODO make alias of PowerPolicy_PerProcess if it works correctly
       PP("imx8_per_slice", PowerPolicy_Imx8_PerSlice, 0),
   };
 

--- a/src/power_policy/per_process.hpp
+++ b/src/power_policy/per_process.hpp
@@ -25,11 +25,8 @@ private:
 public:
     PowerPolicy_PerProcess()
     {
-        for (auto &p : pm.policy_iter()) {
-            if (!p.available_frequencies)
-                throw runtime_error("Cannot list available frequencies for the CPU");
+        for (auto &p : pm.policy_iter())
             clusters.emplace_back(p);
-        }
     }
 
     // Validate that the requested frequencies are available

--- a/src/power_policy/per_process.hpp
+++ b/src/power_policy/per_process.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "_power_policy.hpp"
+#include "power_manager.hpp"
+#include "window.hpp"
+#include <algorithm>            // TODO: Move to .cpp
+
+/**
+ * Set frequency based on the currently executing process.
+ *
+ * The requested frequencies for processes are validated at runtime, and when a collision
+ * occurs (multiple processes request different frequencies for the same CPU cluster), an
+ * error message is shown.
+ */
+class PowerPolicy_PerProcess : public PmPowerPolicy
+{
+private:
+    struct CpuCluster {
+        CpufreqPolicy& cf_policy;
+        std::vector<Process *> requesting_procs {};
+        CpuCluster(CpufreqPolicy& cp) : cf_policy(cp) {}
+    };
+    std::vector<CpuCluster> clusters {};
+
+public:
+    PowerPolicy_PerProcess()
+    {
+        for (auto &p : pm.policy_iter()) {
+            if (!p.available_frequencies)
+                throw runtime_error("Cannot list available frequencies for the CPU");
+            clusters.emplace_back(p);
+        }
+    }
+
+    // Validate that the requested frequencies are available
+    void validate(const Windows &windows) override
+    {
+        for (const Window &win : windows) {
+            for (const Slice &slice : win.slices) {
+                for (const Partition *part : { slice.sc, slice.be }) {
+                    if (!part) continue;
+                    for (const Process &proc : part->processes) {
+                        if (!proc.requested_frequency) continue;
+                        for (const CpuCluster &cluster : clusters) {
+                            if (!(slice.cpus & cluster.cf_policy.affected_cores)) continue;
+                            cluster.cf_policy.validate_frequency(proc.requested_frequency.value());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    bool supports_per_process_frequencies() override { return true; }
+
+
+    void on_process_start(Process &proc) override
+    {
+        for (CpuCluster &cc : clusters) {
+            if (proc.requested_frequency &&
+                proc.part.current_cpus() & cc.cf_policy.affected_cores) {
+                // process is requesting a fixed frequency, check if it is
+                //  compatible with existing locks; all locking processes must have requested the
+                //  same frequency, so it suffices to check the first one
+                if (!cc.requesting_procs.empty() &&
+                    cc.requesting_procs[0]->requested_frequency != proc.requested_frequency) {
+                    throw std::runtime_error(
+                      fmt::format("Scheduled processes require different frequencies on the CPU(s) "
+                                  "{}: '{}', '{}' (process 1: '{}', process 2: '{}')",
+                                  cc.cf_policy.affected_cores.as_list(),
+                                  cc.requesting_procs[0]->requested_frequency.value(),
+                                  proc.requested_frequency.value(),
+                                  cc.requesting_procs[0]->argv,
+                                  proc.argv));
+                }
+                cc.requesting_procs.push_back(&proc);
+                cc.cf_policy.write_frequency(proc.requested_frequency.value());
+            }
+        }
+    }
+
+    void on_process_end(Process &process) override
+    {
+	for (auto &cc : clusters) {
+	    auto deleted = std::remove(begin(cc.requesting_procs), end(cc.requesting_procs), &process);
+	    cc.requesting_procs.erase(deleted, end(cc.requesting_procs));
+	}
+    }
+};

--- a/test/0220-test-configs.t
+++ b/test/0220-test-configs.t
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+. testlib
+plan_tests 15
+
+# Test that config files that we ship in test_config can be at least
+# parsed. Several of them are hardware dependent and cannot be
+# executed on arbitrary hardware. Therefore, their automated testing
+# is problematic.
+
+# set fixed log level for config tests; otherwise if user would run something
+#  like `SPDLOG_LEVEL=trace make test`, the output would include the logs and the tests would fail
+export SPDLOG_LEVEL=warning
+
+test_config() {
+    local cfg_in=$1
+
+    okx demos-sched -d -c "../test_config/$cfg_in"
+}
+
+test_config CPU_switching.yaml
+test_config api_init_test.yaml
+test_config api_test-multiple_slices.yaml
+test_config api_test.yaml
+test_config be_partition_window_overflow.yaml
+test_config be_wait.yaml
+test_config environment_test.yaml
+test_config init_slice_cpuset_loading.yaml
+test_config jitter_process.yaml
+test_config more_partitions.yaml
+test_config multiple_processes.yaml
+test_config per_process_power_policy.yaml
+test_config per_process_power_policy2.yaml
+test_config per_process_power_policy_tx2.yaml
+test_config per_slice_power_policy.yaml

--- a/test/meson.build
+++ b/test/meson.build
@@ -4,6 +4,7 @@ tests = '''
 0100-api.t
 0200-config.t
 0210-config_validation.t
+0220-test-configs.t
 '''.split()
 
 foreach t: tests

--- a/test_config/per_process_power_policy_tx2.yaml
+++ b/test_config/per_process_power_policy_tx2.yaml
@@ -1,0 +1,21 @@
+# tests the per_process power policy on NVIDIA TX2
+# we currently don't have a good way to test this in the automated test suite
+
+partitions:
+  - name: SC1
+    processes:
+      - cmd: yes > /dev/null
+        budget: 1500
+        frequency: 345.6
+  - name: BE1
+    processes:
+      - cmd: yes > /dev/null
+        budget: 1500
+        frequency: 652.8
+windows:
+  - length: 1500
+    slices:
+      - cpu: 0
+        sc_partition: SC1
+      - cpu: 4
+        be_partition: BE1


### PR DESCRIPTION
This is just a simple modification of imx8-per-process. If it works
well, we'll replace imx8-per-process with this platform independent
policy.