### PR TITLE
Reactive policies

### DIFF
--- a/src/power_policy/_power_policy.cpp
+++ b/src/power_policy/_power_policy.cpp
@@ -15,6 +15,10 @@
 #include "power_policy/minbe.hpp"
 #include "power_policy/none.hpp"
 #include "power_policy/per_process.hpp"
+#include "power_policy/bets_skip.hpp"
+#include "power_policy/bets_soft_throttle.hpp"
+#include "power_policy/bets_hard_throttle.hpp"
+
 
 
 // after multiple template-based attempts, a macro solution was chosen,
@@ -51,6 +55,9 @@ static const std::map<std::string,
       PP("imx8_fixed", PowerPolicy_Imx8_Fixed, 2),
       PP("imx8_per_process", PowerPolicy_Imx8_PerProcess, 0), // TODO make alias of PowerPolicy_PerProcess if it works correctly
       PP("imx8_per_slice", PowerPolicy_Imx8_PerSlice, 0),
+      PP("bets_skip", Bets_skip, 1),
+      PP("bets_soft_throttle", Bets_soft_throttle, 1),
+      PP("bets_hard_throttle", Bets_hard_throttle, 1),
   };
 
 

--- a/src/power_policy/bets_hard_throttle.hpp
+++ b/src/power_policy/bets_hard_throttle.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "bets_policy.hpp"
+
+/**
+ * In case of temperature threshold overstepping set frequencies to the lowest possible frequency.
+ *
+ * Based on imx8_per_slice policy.
+ */
+class Bets_hard_throttle : public Bets_policy
+{
+public:
+    Bets_hard_throttle(const std::string &temperature_threshold) : Bets_policy(temperature_threshold) {}
+
+    void execute_policy(CpufreqPolicy *cp, CpuFrequencyHz &freq, Window &win) override {
+        cp->write_frequency(cp->min_frequency);
+    }
+};

--- a/src/power_policy/bets_policy.hpp
+++ b/src/power_policy/bets_policy.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "_power_policy.hpp"
+#include "power_manager.hpp"
+#include "lib/file_lib.hpp"
+#include <fstream>
+#include <iostream>
+#include "slice.hpp"
+#include <optional>
+
+/**
+ * Based on imx8_per_slice policy, intended for Best Effort Task Scheduler (BETS).
+ */
+class Bets_policy : public PmPowerPolicy
+{
+protected:
+    // currently, this is hardcoded for i.MX8, but should be quite simply extensible
+    //  for other CPU cluster layouts
+    std::array<CpufreqPolicy *, 2> policies{ &pm.get_policy("policy0"), &pm.get_policy("policy4") };
+    float upper_threshold;
+    float lower_threshold;      //TODO: another argument or is fixed margin of 2°C good enough?
+    bool reactive_policy_in_place = false;
+    const string temp_path_c0 = "/sys/devices/virtual/thermal/thermal_zone0/temp";
+
+public:
+    Bets_policy(const std::string &temperature_threshold)
+    {
+        upper_threshold = std::stof(temperature_threshold);
+        lower_threshold = upper_threshold - 2;
+        for (auto &p : pm.policy_iter())
+            if (!p.available_frequencies)
+                throw runtime_error("Cannot list available frequencies for the CPU"
+                                    " - are you sure you're running DEmOS on an i.MX8?");
+    }
+
+    // Validate that the requested frequencies are available
+    void validate(const Windows &windows) override
+    {
+        for (const Window &win : windows) {
+            for (const Slice &slice : win.slices) {
+                if (!slice.requested_frequency) continue;
+                for (const CpufreqPolicy *policy : policies) {
+                    if (!(slice.cpus & policy->affected_cores)) continue;
+                    policy->validate_frequency(slice.requested_frequency.value());
+                }
+            }
+        }
+    }
+    bool supports_per_slice_frequencies() override { return true; }
+
+    float get_temperature_on_c0(){
+        auto is = file_open<std::ifstream>(temp_path_c0);
+        float temp;
+        is >> temp;
+        return temp / 1000.0;
+    }
+
+    virtual void execute_policy(CpufreqPolicy *cp, CpuFrequencyHz &freq, Window &win){
+        cp->write_frequency(freq);
+    }
+
+    void on_window_start(Window &win) override
+    {
+        for (CpufreqPolicy *cp : policies) {
+            std::optional<CpuFrequencyHz> freq = std::nullopt;
+            for (const Slice &slice : win.slices) {
+                if (slice.requested_frequency && slice.cpus & cp->affected_cores) {
+                    // slice is requesting a fixed frequency, check that all slices on the
+                    // same CPU cluster request the same frequency.
+                    if (freq.has_value() && freq.value() != slice.requested_frequency) {
+                        throw std::runtime_error(fmt::format(
+                                "Scheduled slices require different frequencies on the CPU(s) "
+                                "{}: '{}', '{}'",
+                                cp->affected_cores.as_list(),
+                                freq.value(),
+                                slice.requested_frequency.value()));
+                    }
+                    freq = slice.requested_frequency;
+                }
+            }
+            if (freq.has_value()) {
+                if ((!reactive_policy_in_place && get_temperature_on_c0() <= upper_threshold) ||
+                        (reactive_policy_in_place && get_temperature_on_c0() <= lower_threshold)) {
+                    reactive_policy_in_place = false;
+                    cp->write_frequency(freq.value());
+                } else {
+                    reactive_policy_in_place = true;
+                    execute_policy(cp, freq.value(), win);
+                }
+            }
+        }
+    }
+};

--- a/src/power_policy/bets_skip.hpp
+++ b/src/power_policy/bets_skip.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "bets_policy.hpp"
+#include <map>
+#include <limits>
+#include <iostream>
+
+/**
+ * In case of temperature threshold overstepping skip a task in a fair fashion.
+ *
+ * Based on imx8_per_slice policy.
+ */
+class Bets_skip : public Bets_policy
+{
+private:
+    std::map<std::string, int> skip_counter;
+public:
+    Bets_skip(const std::string &temperature_threshold) : Bets_policy(temperature_threshold) {}
+
+    void execute_policy(CpufreqPolicy *cp, CpuFrequencyHz &freq, Window &win) override {
+        cp->write_frequency(freq);
+
+        int min = std::numeric_limits<int>::max();
+        std::string candidate;
+        int can_idx = 0;
+        int i = 0;
+        for (auto &s : win.slices){
+            std::string key = s.be->get_name();
+            if (key.find("sleep") == std::string::npos){ //Sleep process is used for idle time.
+                if(!skip_counter.count(key)){
+                    skip_counter.insert(std::pair<std::string, int>(key, 0));
+                    min = 0;
+                    candidate = key;
+                    can_idx = i;
+                } else {
+                    if (skip_counter[key] < min){
+                        min = skip_counter[key];
+                        can_idx = i;
+                        candidate = key;
+                    }
+                }
+            }
+            i++;
+        }
+        skip_counter[candidate]++;
+
+        for (int j = 0; j < win.slices.size(); j++){
+            win.to_be_skipped[j] = false;
+        }
+        win.to_be_skipped[can_idx] = true;
+    }
+};
+

--- a/src/power_policy/bets_skip.hpp
+++ b/src/power_policy/bets_skip.hpp
@@ -1,9 +1,15 @@
 #pragma once
 
 #include "bets_policy.hpp"
-#include <map>
-#include <limits>
 #include <iostream>
+#include <vector>
+#include <utility>
+#include <algorithm>
+
+
+bool cmp(std::pair<std::string, int>& a, std::pair<std::string, int>& b) {
+    return a.second < b.second;
+}
 
 /**
  * In case of temperature threshold overstepping skip a task in a fair fashion.
@@ -13,41 +19,64 @@
 class Bets_skip : public Bets_policy
 {
 private:
-    std::map<std::string, int> skip_counter;
+    std::vector<std::pair<std::string, int>> candidates;
+    std::vector<std::string> present;
 public:
     Bets_skip(const std::string &temperature_threshold) : Bets_policy(temperature_threshold) {}
 
-    void execute_policy(CpufreqPolicy *cp, CpuFrequencyHz &freq, Window &win) override {
-        cp->write_frequency(freq);
 
-        int min = std::numeric_limits<int>::max();
-        std::string candidate;
-        int can_idx = 0;
-        int i = 0;
+    void sort_candidates(){
+        std::sort(candidates.begin(), candidates.end(), cmp);
+    }
+
+    void safe_pushback(std::string key){
+        for (auto &p : candidates){
+            if (p.first == key){
+                return;
+            }
+        }
+        candidates.push_back(std::pair<std::string, int>(key, 0));
+    }
+
+    void load(Window &win){
+        present = std::vector<std::string>();
         for (auto &s : win.slices){
             std::string key = s.be->get_name();
             if (key.find("sleep") == std::string::npos){ //Sleep process is used for idle time.
-                if(!skip_counter.count(key)){
-                    skip_counter.insert(std::pair<std::string, int>(key, 0));
-                    min = 0;
-                    candidate = key;
-                    can_idx = i;
-                } else {
-                    if (skip_counter[key] < min){
-                        min = skip_counter[key];
-                        can_idx = i;
-                        candidate = key;
-                    }
-                }
+                present.push_back(key);
+                safe_pushback(key);
             }
-            i++;
         }
-        skip_counter[candidate]++;
+    }
 
+    int is_present(std::string key){
+        for (int i = 0; i < present.size(); i++){
+            if (present[i] == key){
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    void execute_policy(CpufreqPolicy *cp, CpuFrequencyHz &freq, Window &win) override {
+        cp->write_frequency(freq);
+        if(this->level > 5){
+            this->level = 5;
+        }
+        int skip_counter = this->level;
         for (int j = 0; j < win.slices.size(); j++){
             win.to_be_skipped[j] = false;
         }
-        win.to_be_skipped[can_idx] = true;
+        load(win);
+        sort_candidates();
+        for(int i = 0; i < candidates.size() && skip_counter > 0; i++){
+            int idx = is_present(candidates[i].first);
+            if (idx != -1){
+                win.to_be_skipped[idx] = true;
+                candidates[i].second += win.length.count();
+                skip_counter--;
+            }
+        }
     }
 };
 

--- a/src/power_policy/bets_skip.hpp.save
+++ b/src/power_policy/bets_skip.hpp.save
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "bets_policy.hpp"
+#include <map>
+#include <limits>
+#include <iostream>
+
+/**
+ * In case of temperature threshold overstepping set frequencies to the lowest possible frequency.
+ *
+ * Based on imx8_per_slice policy.
+ */
+class Bets_skip : public Bets_policy
+{
+private:
+    std::map<std::string, int> skip_counter;
+public:
+    Bets_skip(const std::string &temperature_threshold) : Bets_policy(temperature_threshold) {}
+
+    void execute_policy(CpufreqPolicy *cp, CpuFrequencyHz &freq, Window &win) override {
+        cp->write_frequency(freq);
+
+        int min = std::numeric_limits<int>::max();
+        std::string candidate;
+        int i = 0;
+        for (auto &s : win.slices){
+            std::string key = s.be->get_name();
+            if (!skip_counter.count(key)){
+                skip_counter.insert(std::pair<std::string, int>(key, 0));
+                min = 0;
+                candidate = key;
+            } else {
+                if (skip_counter[key] < min){
+                    min = skip_counter[key];
+                    candidate = key;
+                }
+            }
+            i++;
+        }
+        for (auto pair : win.to_){
+            win.to_be_skipped[j] = false;
+        }
+
+        for (int j = 0; j < )
+
+        win.to_be_skipped[candidate] = true;
+    }
+};
+

--- a/src/power_policy/bets_soft_throttle.hpp
+++ b/src/power_policy/bets_soft_throttle.hpp
@@ -2,6 +2,7 @@
 
 #include "bets_policy.hpp"
 
+
 /**
  * In case of temperature threshold overstepping lower frequencies by one step (if possible).
  *

--- a/src/power_policy/bets_soft_throttle.hpp
+++ b/src/power_policy/bets_soft_throttle.hpp
@@ -13,10 +13,15 @@ public:
     Bets_soft_throttle(const std::string &temperature_threshold) : Bets_policy(temperature_threshold) {}
 
     void execute_policy(CpufreqPolicy *cp, CpuFrequencyHz &freq, Window &win) override {
+        if (this->level > 3){
+            this->level = 3;
+        }
 	auto freqs = cp->available_frequencies.value();
         auto it = std::find(freqs.begin(), freqs.end(), freq);
         if (it != freqs.end()){
-            it = it == freqs.begin() ? it : --it;   // If it can be lowered, lower it.
+            for(int i = 0; i < this->level; i++){
+                it = it == freqs.begin() ? it : --it;   // If it can be lowered, lower it.
+            }
             cp->write_frequency(*it);
         } else {
             throw std::runtime_error(fmt::format(

--- a/src/power_policy/bets_soft_throttle.hpp
+++ b/src/power_policy/bets_soft_throttle.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "bets_policy.hpp"
+
+/**
+ * In case of temperature threshold overstepping lower frequencies by one step (if possible).
+ *
+ * Based on imx8_per_slice policy.
+ */
+class Bets_soft_throttle : public Bets_policy
+{
+public:
+    Bets_soft_throttle(const std::string &temperature_threshold) : Bets_policy(temperature_threshold) {}
+
+    void execute_policy(CpufreqPolicy *cp, CpuFrequencyHz &freq, Window &win) override {
+	auto freqs = cp->available_frequencies.value();
+        auto it = std::find(freqs.begin(), freqs.end(), freq);
+        if (it != freqs.end()){
+            it = it == freqs.begin() ? it : --it;   // If it can be lowered, lower it.
+            cp->write_frequency(*it);
+        } else {
+            throw std::runtime_error(fmt::format(
+                    "Frequency not found in available frequencies "
+                    "'{}'",
+                    freq));
+        }
+    }
+};

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -5,6 +5,7 @@
 #include <ev++.h>
 #include <list>
 #include <optional>
+#include <vector>
 
 class Window;
 class PowerPolicy;
@@ -28,6 +29,7 @@ public:
     const std::chrono::milliseconds length;
     // use std::list as Slice doesn't have move and copy constructors
     std::list<Slice> slices{};
+    std::vector<bool> to_be_skipped;
 
     Window(ev::loop_ref loop, std::chrono::milliseconds length, PowerPolicy &power_policy);
 


### PR DESCRIPTION
Contains reactive policies. They take single argument, that is temperute level.
Bets_policy.hpp contains general policy framework, which reacts on temperature threshold overstepping and increases "level" variable. Higher level means more strict policy application. If level != 0, virtual function execute_policy is executed. Otherwise it acts like imx8_per_window policy.
Bets_skip.hpp contains skipping policy. Iterates over all tasks in each window and skips up to 5 of them (to keep one running), based on "level" variable.
Bets_soft_throttle.hpp reduces frequency of tasks in each window by 1 - 3 levels based on "level" variable.